### PR TITLE
correct af max calculation for strs

### DIFF
--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -82,12 +82,17 @@ class VariantUtils():
             is not seen in any populations in the JSON
         '''
         highest_af = 0
-        if variant['variantAttributes']['alleleFrequencies'] is not None:
+        print(type(highest_af))
+        if variant['variantAttributes']['alleleFrequencies'] is None:
+            highest_af = '-'
+        else:
             for af in variant['variantAttributes']['alleleFrequencies']:
                 if af['alternateFrequency'] > highest_af:
                     highest_af = af['alternateFrequency']
+            if highest_af == 0:
+                highest_af = '-'
 
-        return highest_af
+        return str(highest_af)
 
     @staticmethod
     def get_inheritance(variant, mother_idx, father_idx, p_sex):
@@ -226,13 +231,14 @@ class VariantUtils():
         var_dict["End"] = variant["coordinates"]["end"]
         var_dict["Length"] = abs(var_dict["End"] - var_dict["Pos"])
         var_dict["Type"] = "STR"
-        var_dict["Priority"] = "STR"
+        var_dict["Priority"] = "TIER1_STR"
         var_dict["Repeat"] = variant[
             "shortTandemRepeatReferenceData"
         ]["repeatedSequence"]
         var_dict["STR1"] = num_copies(variant, pb_idx, 0)
         var_dict["STR2"] = num_copies(variant, pb_idx, 1)
         var_dict["Gene"] = VariantUtils.get_gene_symbol(variant)
+        var_dict["AF Max"] = VariantUtils.get_af_max(variant)
         return var_dict
 
     @staticmethod

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -78,11 +78,11 @@ class VariantUtils():
             variant (dict): dict describing a single variant from JSON
         Outputs:
             highest_af: frequency of the variant in the population with
-            the highest allele frequency for the variant, or 0 if the variant
-            is not seen in any populations in the JSON
+            the highest allele frequency for the variant, or - if the variant
+            is not seen in any populations in the JSON, or - if there are no
+            reference populations.
         '''
         highest_af = 0
-        print(type(highest_af))
         if variant['variantAttributes']['alleleFrequencies'] is None:
             highest_af = '-'
         else:

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -629,8 +629,8 @@ class excel():
         a ref or an alt sequence > 1
         '''
         if (
-            len(variant["variantCoordinates"]["reference"]) > 1 or
-            len(variant["variantCoordinates"]["alternate"]) > 1
+                len(variant["variantCoordinates"]["reference"]) > 1 or
+                len(variant["variantCoordinates"]["alternate"]) > 1
             ):
             threshold = self.config['denovo_quality_scores']['indel']
         else:

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -628,10 +628,8 @@ class excel():
         This function works out if a variant is an indel based on having either
         a ref or an alt sequence > 1
         '''
-        if (
-                len(variant["variantCoordinates"]["reference"]) > 1 or
-                len(variant["variantCoordinates"]["alternate"]) > 1
-            ):
+        if (len(variant["variantCoordinates"]["reference"]) > 1 or
+                len(variant["variantCoordinates"]["alternate"]) > 1):
             threshold = self.config['denovo_quality_scores']['indel']
         else:
             threshold = self.config['denovo_quality_scores']['snv']

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -627,10 +627,11 @@ class excel():
         The de novo quality score thresholds are different for indels or SNVs
         This function works out if a variant is an indel based on having either
         a ref or an alt sequence > 1
-        
         '''
-        if (len(variant["variantCoordinates"]["reference"]) > 1 or
-            len(variant["variantCoordinates"]["alternate"])> 1):
+        if (
+            len(variant["variantCoordinates"]["reference"]) > 1 or
+            len(variant["variantCoordinates"]["alternate"]) > 1
+            ):
             threshold = self.config['denovo_quality_scores']['indel']
         else:
             threshold = self.config['denovo_quality_scores']['snv']
@@ -707,8 +708,10 @@ class excel():
             ]["interpretedGenomeData"]["variants"]:
             for event in snv["reportEvents"]:
                 if event['deNovoQualityScore'] is not None:
-                    if (event['deNovoQualityScore'] >
-                        self.get_de_novo_threshold(snv)):
+                    if (
+                        event['deNovoQualityScore'] >
+                        self.get_de_novo_threshold(snv)
+                        ):
                         event_index = snv["reportEvents"].index(event)
                         var_dict = VariantUtils.get_snv_info(
                             snv,

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -264,22 +264,22 @@ class TestDeNovoThresholds():
     '''
     variants = [
         {
-        "variantCoordinates": {
-            "reference": "GT",
-            "alternate": "G"
-            },
+            "variantCoordinates": {
+                "reference": "GT",
+                "alternate": "G"
+                },
         },
         {
-        "variantCoordinates": {
-            "reference": "C",
-            "alternate": "G"
-            },
+            "variantCoordinates": {
+                "reference": "C",
+                "alternate": "G"
+                },
         },
         {
-        "variantCoordinates": {
-            "reference": "A",
-            "alternate": "AC"
-            },
+            "variantCoordinates": {
+                "reference": "A",
+                "alternate": "AC"
+                },
         },
     ]
     config = {
@@ -288,6 +288,7 @@ class TestDeNovoThresholds():
             "snv": 0.0013
         }
     }
+
     def test_deletion_de_novo_threshold_correct(self):
         '''
         Test that get_de_novo_threshold gets correct threshold for an deletion

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -254,3 +254,54 @@ class TestVariantNomenclature():
             refseq_tsv, "ENST0000033"
         ) == "ENSP0000044"
 
+
+class TestDeNovoThresholds():
+    '''
+    Tests for function that gets the de novo quality score threshold based on
+    the ref and alt of the variant. The threshold should be different for
+    indels and SNVs, so this test assumes that a ref or alt longer than one
+    base is an indel.
+    '''
+    variants = [
+        {
+        "variantCoordinates": {
+            "reference": "GT",
+            "alternate": "G"
+            },
+        },
+        {
+        "variantCoordinates": {
+            "reference": "C",
+            "alternate": "G"
+            },
+        },
+        {
+        "variantCoordinates": {
+            "reference": "A",
+            "alternate": "AC"
+            },
+        },
+    ]
+    config = {
+        "denovo_quality_scores": {
+            "indel": 0.02,
+            "snv": 0.0013
+        }
+    }
+    def test_deletion_de_novo_threshold_correct(self):
+        '''
+        Test that get_de_novo_threshold gets correct threshold for an deletion
+        '''
+        assert excel.get_de_novo_threshold(self, self.variants[0]) == 0.02
+
+    def test_snv_de_novo_threshold_correct(self):
+        '''
+        Test that get_de_novo_threshold gets correct threshold for an SNV
+        '''
+        assert excel.get_de_novo_threshold(self, self.variants[1]) == 0.0013
+
+    def test_insertion_de_novo_threshold_correct(self):
+        '''
+        Test that get_de_novo_threshold gets correct threshold for an insertion
+        '''
+        assert excel.get_de_novo_threshold(self, self.variants[2]) == 0.02

--- a/src/code.sh
+++ b/src/code.sh
@@ -21,7 +21,7 @@ main() {
     /usr/bin/time -v python3 start_process.py \
     --json /home/dnanexus/in/json/*json \
     --mane_file /home/dnanexus/in/mane_file/* \
-    --refseq_tsv /home/dnanexus/in/refseq_tsv/*tsv \
+    --refseq_tsv /home/dnanexus/in/refseq_tsv/* \
     --config /home/dnanexus/in/config/*json \
     $args
 


### PR DESCRIPTION
- Change AF max function so '-' is returned if 1. there are no GEL reference populations or 2. the variant is not seen in GEL reference populations
- Change refseq_tsv input to be .tsv.gz file
- add function to detemine which threshold to use for a small variant (i.e. if it is an SNV or an indel)
- delete CNV de novo filtering (this was a useless loop as no CNVs have de novo quality scores (oops!))
- add new TestDeNovoThresholds class to test that de novo thresholds are determined correctly.

Successful DX job using this version of the app: https://platform.dnanexus.com/panx/projects/GkvYVxj47gjx87kbgv61ZVQQ/monitor/job/Gkyjp8Q47gjxbkB3XPk8F4pY

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/4)
<!-- Reviewable:end -->
