### PR TITLE
convert all df columns to object type

### DIFF
--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -719,6 +719,10 @@ class excel():
             # Get list of all columns except 'Priority' column
             col_except_priority = self.column_list
             col_except_priority.remove('Priority')
+            # Convert all df columns to object type to allow merging without
+            # conflicts
+            ex_df = ex_df.astype(object)
+            self.var_df = self.var_df.astype(object)
             # Merge exomiser df with tiered variants df, indicating if there
             # is a difference between Priority
             ex_df = ex_df.merge(


### PR DESCRIPTION
Fix so that the additional analysis and GEL tiering dataframes have all columns as the object type to avoid conflicts on merging

Old job before this fix that failed on type conflicts: https://platform.dnanexus.com/panx/projects/GkvYVxj47gjx87kbgv61ZVQQ/monitor/job/Gp18q0847gjvjP43j4P4353B

New job post fixing that shows this has solved the problem: https://platform.dnanexus.com/panx/projects/GkvYVxj47gjx87kbgv61ZVQQ/monitor/job/Gp1935847gjVjypXY3q97Q96

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/6)
<!-- Reviewable:end -->
