### PR TITLE
add exomiser score threshold filter

### DIFF
--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -658,7 +658,13 @@ class excel():
                 snv['reportEvents'] = top_event
                 ranked.append(snv)
 
-        to_report = VariantUtils.get_top_3_ranked(ranked)
+        # We only want Exomiser variants with a score >= 0.75, so we need to
+        # filter the list to keep only these
+        ranked_and_above_threshold = [
+            x for x in ranked if x['reportEvents']['score'] >= 0.75
+        ]
+
+        to_report = VariantUtils.get_top_3_ranked(ranked_and_above_threshold)
 
         for snv in to_report:
             # put reportevents dict within a list to allow it to have an index


### PR DESCRIPTION
Need to filter out variants with a score less than 0.75. This update adds a filter to remove these

Old job with low scoring exomiser variants left in: https://platform.dnanexus.com/panx/projects/GkvYVxj47gjx87kbgv61ZVQQ/monitor/job/Gp19VPj47gjqF193kZ80f694

New job with these filtered out: https://platform.dnanexus.com/panx/projects/GkvYVxj47gjx87kbgv61ZVQQ/monitor/job/Gp1yyY847gjxgXx9KbG1P32B

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/7)
<!-- Reviewable:end -->
