### PR TITLE
Di 1112 exomiser ranking fix

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,27 @@
+name: pytest
+on:
+  push:
+    branches:
+      - main
+      - DI-1112_exomiser-ranking-fix
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8.10
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run unit tests
+        run: python -m pytest resources/home/dnanexus/tests/test_make_workbook.py 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8.10
+          python-version: 3.8.18
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - DI-1112_exomiser-ranking-fix
   pull_request:
     branches:
       - main

--- a/dxapp.json
+++ b/dxapp.json
@@ -5,8 +5,7 @@
     "whatsNew": {
       "1.0.0": "Initial version",
       "1.1.0": "Fix to make compatible with older GEL JSONs",
-      "1.1.1": "Bug fix for workbooks with no GEL tiering variants",
-      "1.2.0": "Feedback changes"
+      "1.2.0": "Feedback changes, correct exomiser ranking, fix bugs"
       },
     "dxapi": "1.0.0",
     "version": "1.2.0",

--- a/dxapp.json
+++ b/dxapp.json
@@ -5,10 +5,11 @@
     "whatsNew": {
       "1.0.0": "Initial version",
       "1.1.0": "Fix to make compatible with older GEL JSONs",
-      "1.1.1": "Bug fix for workbooks with no GEL tiering variants"
+      "1.1.1": "Bug fix for workbooks with no GEL tiering variants",
+      "1.2.0": "Feedback changes"
       },
     "dxapi": "1.0.0",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "inputSpec": [
       {
         "name": "json",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ openpyxl==3.1.2
 pandas==1.4.1
 Pillow==9.2.0
 pytest==7.0.1
-pytest-subtests=0.13.1
+pytest-subtests==0.13.1
 pytz==2021.3
 networkx==2.8.5

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -329,64 +329,38 @@ class VariantUtils():
         return var_dict
 
     @staticmethod
-    def get_top_3_ranked(ranked):
+    def get_top_3_ranked(df):
         '''
-        Get top 3 ranked Exomiser variants; this function uses a podium format
-        so that equal ranks can be reported back.
-        Uses gold, silver and bronze to refer to the top, second and third
-        ranked variants. It will return all variants at each rank; so all the
-        first ranked, all the second ranked and all the third ranked variants.
+        Filter a df to return a df of the top 3 ranked Exomiser variants; this
+        function uses a podium format so that equal ranks can be reported back.
+        It will return all variants at each rank; so all the first ranked, all
+        the second ranked and all the third ranked variants.
         Inputs
-            ranked (dict): dict of indices within the df and integer denoting
-            Exomiser rank for the variant at that index
-            e.g. {1: 1, 2: 3, 3: 5, 4: 5, 5: 7}
+            df (pd.Dataframe): variant dataframe with a column containing
+            strings of the exomiser ranks in the format "Exomiser Rank #"
         Outputs:
-            top (list): df indices of variants in the top three Exomiser ranks
+            df (pd.Dataframe): filtered variant dataframe containing only
+            variants in the top three ranks
         '''
-        gold = []
-        silver = []
-        bronze = []
-        top = []
+        # Create df copy to modify avoid the SettingWithCopyWarning
+        df = df.copy()
+        # First change "Exomiser Rank #" string to int
+        df['Priority'] = df['Priority'].map(
+            lambda x: int(x.split(' ')[-1].split('.')[0])
+        )
+        # Get unique ranks and sort, selecting the top three ranks
+        unique_ranks = df['Priority'].unique()
+        top_3_ranks = sorted(unique_ranks)[:3]
 
-        # order the dictionary by rank, so the highest rank appears first
-        # then use this to loop through the dictionary and keep the first
-        # variant at each rank and any subsequent variant that has the same
-        # rank, for each of the top three ranks.
-        ordered = dict(sorted(ranked.items(), key=lambda item: item[1]))
+        # filter the df to include only values in top three ranks
+        df = df[df['Priority'].isin(top_3_ranks)]
 
-        for k, v in ordered.items():
-            if not gold:
-                gold.append(v)
-                top.append(k)
-                continue
-            else:
-                if v == gold[0]:
-                    gold.append(v)
-                    top.append(k)
-                    continue
-
-            if not silver:
-                silver.append(v)
-                top.append(k)
-                continue
-            else:
-                if v == silver[0]:
-                    silver.append(v)
-                    top.append(k)
-                    continue
-
-            if not bronze:
-                bronze.append(v)
-                top.append(k)
-                continue
-            else:
-                if v == bronze[0]:
-                    bronze.append(v)
-                    top.append(k)
-                    continue
-                else:
-                    break
-        return top
+        # Change int values back to "Exomiser Rank #" str
+        df = df.copy()
+        df['Priority'] = df['Priority'].map(
+            lambda x: f"Exomiser Rank {str(x)}"
+        )
+        return df
 
 
 class VariantNomenclature():

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -337,7 +337,9 @@ class VariantUtils():
         ranked variants. It will return all variants at each rank; so all the
         first ranked, all the second ranked and all the third ranked variants.
         Inputs
-            ranked (dict): dict of indices and Exomiser ranks from exomiser df
+            ranked (dict): dict of indices within the df and Exomiser ranks
+            from exomiser df
+            e.g. {1: 1, 2: 3, 3: 5, 4: 5, 5: 7}
         Outputs:
             top (list): df indices of variants in the top three Exomiser ranks
         '''
@@ -346,9 +348,13 @@ class VariantUtils():
         bronze = []
         top = []
 
-        ordered_list = dict(sorted(ranked.items(), key=lambda item: item[1]))
+        # order the dictionary by rank, so the highest rank appears first
+        # then use this to loop through the dictionary and keep the first
+        # variant at each rank and any subsequent variant that has the same
+        # rank, for each of the top three ranks.
+        ordered = dict(sorted(ranked.items(), key=lambda item: item[1]))
 
-        for k, v in ordered_list.items():
+        for k, v in ordered.items():
             if not gold:
                 gold.append(v)
                 top.append(k)

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -1,5 +1,4 @@
 import re
-import pandas as pd
 
 class VariantUtils():
     '''
@@ -353,7 +352,6 @@ class VariantUtils():
         # filter the df to include only values in top three ranks
         df = df[df['priority_as_int'].isin(top_3_ranks)]
         df.drop(['priority_as_int'], axis=1, inplace=True)
-        print(pd.__version__) 
         return df
 
 

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -337,46 +337,50 @@ class VariantUtils():
         ranked variants. It will return all variants at each rank; so all the
         first ranked, all the second ranked and all the third ranked variants.
         Inputs
-            ranked (list): list of Exomiser variants
+            ranked (dict): dict of indices and Exomiser ranks from exomiser df
         Outputs:
-            to_report (list): top three Exomiser variants to report back
+            top (list): df indices of variants in the top three Exomiser ranks
         '''
         gold = []
         silver = []
         bronze = []
+        top = []
 
-        rank = lambda x: x['reportEvents']['vendorSpecificScores']['rank']
+        ordered_list = dict(sorted(ranked.items(), key=lambda item: item[1]))
 
-        ordered_list = sorted(ranked, key=rank)
-
-        for snv in ordered_list:
+        for k, v in ordered_list.items():
             if not gold:
-                gold.append(snv)
+                gold.append(v)
+                top.append(k)
                 continue
             else:
-                if rank(snv) == rank(gold[0]):
-                    gold.append(snv)
+                if v == gold[0]:
+                    gold.append(v)
+                    top.append(k)
                     continue
 
             if not silver:
-                silver.append(snv)
+                silver.append(v)
+                top.append(k)
                 continue
             else:
-                if rank(snv) == rank(silver[0]):
-                    silver.append(snv)
+                if v == silver[0]:
+                    silver.append(v)
+                    top.append(k)
                     continue
 
             if not bronze:
-                bronze.append(snv)
+                bronze.append(v)
+                top.append(k)
                 continue
             else:
-                if rank(snv) == rank(bronze[0]):
-                    bronze.append(snv)
+                if v == bronze[0]:
+                    bronze.append(v)
+                    top.append(k)
                     continue
                 else:
                     break
-
-        return gold + silver + bronze
+        return top
 
 
 class VariantNomenclature():

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -337,8 +337,8 @@ class VariantUtils():
         ranked variants. It will return all variants at each rank; so all the
         first ranked, all the second ranked and all the third ranked variants.
         Inputs
-            ranked (dict): dict of indices within the df and Exomiser ranks
-            from exomiser df
+            ranked (dict): dict of indices within the df and integer denoting
+            Exomiser rank for the variant at that index
             e.g. {1: 1, 2: 3, 3: 5, 4: 5, 5: 7}
         Outputs:
             top (list): df indices of variants in the top three Exomiser ranks

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -1,5 +1,5 @@
 import re
-
+import pandas as pd
 
 class VariantUtils():
     '''
@@ -342,24 +342,18 @@ class VariantUtils():
             df (pd.Dataframe): filtered variant dataframe containing only
             variants in the top three ranks
         '''
-        # Create df copy to modify avoid the SettingWithCopyWarning
-        df = df.copy()
         # First change "Exomiser Rank #" string to int
-        df['Priority'] = df['Priority'].map(
-            lambda x: int(x.split(' ')[-1].split('.')[0])
+        df['priority_as_int'] = df['Priority'].map(
+            lambda x: int(x.split(' ')[-1])
         )
         # Get unique ranks and sort, selecting the top three ranks
-        unique_ranks = df['Priority'].unique()
+        unique_ranks = df['priority_as_int'].unique()
         top_3_ranks = sorted(unique_ranks)[:3]
 
         # filter the df to include only values in top three ranks
-        df = df[df['Priority'].isin(top_3_ranks)]
-
-        # Change int values back to "Exomiser Rank #" str
-        df = df.copy()
-        df['Priority'] = df['Priority'].map(
-            lambda x: f"Exomiser Rank {str(x)}"
-        )
+        df = df[df['priority_as_int'].isin(top_3_ranks)]
+        df.drop(['priority_as_int'], axis=1, inplace=True)
+        print(pd.__version__) 
         return df
 
 

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -805,17 +805,7 @@ class excel():
         if not ex_df.empty:
             # Now we have filtered out all variants that are in the GEL tiering
             # page we need to get the top 3 ranks in the exomiser df
-            ex_df = ex_df.reset_index()
-            # Create dict of {df index: int(exomiser rank)} by removing the
-            # Exomiser Rank prefix from each rank in the df
-            ranks = ex_df['Priority'].to_dict()
-            for k,v in ranks.items():
-                ranks[k] = int(v.split(' ')[-1].split('.')[0])
-            # Get indices of top ranked variants
-            top_ranked_indices = VariantUtils.get_top_3_ranked(ranks)
-            # Keep only top ranked variants + drop col with prev indices
-            ex_df = ex_df.iloc[top_ranked_indices]
-            ex_df = ex_df.drop(columns=['index'])
+            ex_df = VariantUtils.get_top_3_ranked(ex_df)
 
             # Sort df by priority first, and then gene name
             ex_df = ex_df.sort_values(['Priority', 'Gene'])

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -732,7 +732,6 @@ class excel():
             # event index will always be 0 as we have made it so there is only
             # the top ranked event
             event_index = 0
-            rank = snv['reportEvents'][0]['vendorSpecificScores']['rank']
             var_dict = VariantUtils.get_snv_info(
                 snv,
                 self.proband,
@@ -742,6 +741,7 @@ class excel():
                 self.father,
                 self.proband_sex
             )
+            rank = int(snv['reportEvents'][0]['vendorSpecificScores']['rank'])
             var_dict["Priority"] = f"Exomiser Rank {rank}"
             var_dict["HGVSc"], var_dict["HGVSp"] = (
                 VariantNomenclature.get_hgvs_exomiser(

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -790,17 +790,13 @@ class excel():
                 self.var_df,
                 on=["Chr", 'Pos', 'Ref', 'Alt'],
                 how='left',
-                indicator=True
+                indicator=True,
+                suffixes=[None, "_y"]
             )
             # Keep left only == keep only those that are in exomiser df and
             # not in tiered df
             merge_df = merge_df[merge_df['_merge'] == 'left_only']
-            # Clean up merge columns (drop _merge columns ending _y, rename
-            # columns ending _x)
-            d = {}
-            for col in self.var_df.columns:
-                d[col + '_x'] = col
-            merge_df = merge_df.rename(columns=d)
+            # Clean up df by dropping merge column and columns ending _y
             merge_df = merge_df.drop(columns=['_merge'])
             ex_df = merge_df[merge_df.columns.drop(
                 list(merge_df.filter(regex='.*\_y'))
@@ -810,7 +806,8 @@ class excel():
             # Now we have filtered out all variants that are in the GEL tiering
             # page we need to get the top 3 ranks in the exomiser df
             ex_df = ex_df.reset_index()
-            # Get dict of {index: int(exomiser rank)}
+            # Create dict of {df index: int(exomiser rank)} by removing the
+            # Exomiser Rank prefix from each rank in the df
             ranks = ex_df['Priority'].to_dict()
             for k,v in ranks.items():
                 ranks[k] = int(v.split(' ')[-1].split('.')[0])

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import pandas as pd
 import pytest
 import os
 import obonet
@@ -226,21 +227,35 @@ class TestRanking():
     '''
     Tests for ranking function
     '''
-    snvs = {0: 1, 1: 2, 2: 3, 3: 3, 4: 4}
+    ranks = [1, 2, 3, 3, 4]
+    str_ranks = [f"Exomiser Rank {str(x)}.0" for x in ranks]
+    df = pd.DataFrame({'Priority': str_ranks})
+    print(df)
 
     def test_can_handle_two_bronze(self):
         '''
         Check indices both third ranked items are returned.
         '''
-        assert VariantUtils.get_top_3_ranked(self.snvs) == [0, 1, 2, 3]
+        correct_ranks = [f"Exomiser Rank {str(x)}" for x in self.ranks[:-1]]
+
+        pd.testing.assert_frame_equal(
+            VariantUtils.get_top_3_ranked(self.df),
+            pd.DataFrame({'Priority': correct_ranks})
+        )
 
     def test_next_ranked_returned_if_no_items_at_rank(self):
         '''
         Check that indices for the third and forth ranked items are returned if
         there is no second ranked item
         '''
-        self.snvs[1] = 3
-        assert VariantUtils.get_top_3_ranked(self.snvs) == [0, 1, 2, 3, 4]
+        self.ranks.pop(1)
+        correct_ranks = [f"Exomiser Rank {str(x)}" for x in self.ranks]
+        self.df = self.df.drop([1])
+        pd.testing.assert_frame_equal(
+            VariantUtils.get_top_3_ranked(self.df).reset_index(drop=True),
+            pd.DataFrame({'Priority': correct_ranks}).reset_index(drop=True)
+        )
+
 
 
 class TestVariantNomenclature():

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -226,38 +226,21 @@ class TestRanking():
     '''
     Tests for ranking function
     '''
-    snvs = [
-        {'reportEvents': {'vendorSpecificScores': {'rank': 1}}},
-        {'reportEvents': {'vendorSpecificScores': {'rank': 2}}},
-        {'reportEvents': {'vendorSpecificScores': {'rank': 3}}},
-        {'reportEvents': {'vendorSpecificScores': {'rank': 3}}},
-        {'reportEvents': {'vendorSpecificScores': {'rank': 4}}}
-    ]
+    snvs = {0: 1, 1: 2, 2: 3, 3: 3, 4: 4}
 
     def test_can_handle_two_bronze(self):
         '''
-        Check both third ranked items are returned.
+        Check indices both third ranked items are returned.
         '''
-        assert VariantUtils.get_top_3_ranked(self.snvs) == [
-            {'reportEvents': {'vendorSpecificScores': {'rank': 1}}},
-            {'reportEvents': {'vendorSpecificScores': {'rank': 2}}},
-            {'reportEvents': {'vendorSpecificScores': {'rank': 3}}},
-            {'reportEvents': {'vendorSpecificScores': {'rank': 3}}}
-        ]
+        assert VariantUtils.get_top_3_ranked(self.snvs) == [0, 1, 2, 3]
 
     def test_next_ranked_returned_if_no_items_at_rank(self):
         '''
-        Check that third and forth ranked items are returned if there is no
-        second ranked item
+        Check that indices for the third and forth ranked items are returned if
+        there is no second ranked item
         '''
-        self.snvs[1] = {'reportEvents': {'vendorSpecificScores': {'rank': 3}}}
-        assert VariantUtils.get_top_3_ranked(self.snvs) == [
-            {'reportEvents': {'vendorSpecificScores': {'rank': 1}}},
-            {'reportEvents': {'vendorSpecificScores': {'rank': 3}}},
-            {'reportEvents': {'vendorSpecificScores': {'rank': 3}}},
-            {'reportEvents': {'vendorSpecificScores': {'rank': 3}}},
-            {'reportEvents': {'vendorSpecificScores': {'rank': 4}}}
-        ]
+        self.snvs[1] = 3
+        assert VariantUtils.get_top_3_ranked(self.snvs) == [0, 1, 2, 3, 4]
 
 
 class TestVariantNomenclature():

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -228,7 +228,7 @@ class TestRanking():
     Tests for ranking function
     '''
     ranks = [1, 2, 3, 3, 4]
-    str_ranks = [f"Exomiser Rank {str(x)}.0" for x in ranks]
+    str_ranks = [f"Exomiser Rank {str(x)}" for x in ranks]
     df = pd.DataFrame({'Priority': str_ranks})
     print(df)
 
@@ -236,7 +236,7 @@ class TestRanking():
         '''
         Check indices both third ranked items are returned.
         '''
-        correct_ranks = [f"Exomiser Rank {str(x)}" for x in self.ranks[:-1]]
+        correct_ranks = self.str_ranks[:-1]
 
         pd.testing.assert_frame_equal(
             VariantUtils.get_top_3_ranked(self.df),
@@ -248,12 +248,12 @@ class TestRanking():
         Check that indices for the third and forth ranked items are returned if
         there is no second ranked item
         '''
-        self.ranks.pop(1)
-        correct_ranks = [f"Exomiser Rank {str(x)}" for x in self.ranks]
+        self.str_ranks.pop(1)
         self.df = self.df.drop([1])
+
         pd.testing.assert_frame_equal(
             VariantUtils.get_top_3_ranked(self.df).reset_index(drop=True),
-            pd.DataFrame({'Priority': correct_ranks}).reset_index(drop=True)
+            pd.DataFrame({'Priority': self.str_ranks}).reset_index(drop=True)
         )
 
 


### PR DESCRIPTION
Correct issue where variants in GEL tiering page could be duplicated onto exomiser tiering page.
Prev version shows variants ranked 1, 2, and 3
![image](https://github.com/user-attachments/assets/fc80b346-0e68-4c24-a1f9-500c7b08189e)
although 2 and 3 are already in GEL tiering page

New versions shows 1, 5, and 8, which is correct:
![image](https://github.com/user-attachments/assets/649d043e-3273-4fad-a96a-dfc094c8841e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/11)
<!-- Reviewable:end -->
