### PR TITLE
Di 1486 fix str hemizygous copy count

### DIFF
--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -197,7 +197,7 @@ def index_participant(variant, participant_id):
     return index
 
 
-def get_str_info(variant, proband, columns, ev_idx):
+def get_str_info(variant, proband, columns, ev_idx, pb_sex):
     '''
     Each variant that will be added to the excel workbook, needs to be
     added to the dataframe via a dictionary of values for each column
@@ -234,7 +234,10 @@ def get_str_info(variant, proband, columns, ev_idx):
         "shortTandemRepeatReferenceData"
     ]["repeatedSequence"]
     var_dict["STR1"] = num_copies(variant, pb_idx, 0)
-    var_dict["STR2"] = num_copies(variant, pb_idx, 1)
+    if var_dict["Chr"] in ["X"] and pb_sex == "MALE":
+        var_dict["STR2"] = ""
+    else:
+        var_dict["STR2"] = num_copies(variant, pb_idx, 1)
     var_dict["Gene"] = get_gene_symbol(variant)
     var_dict["AF Max"] = get_af_max(variant)
     return var_dict

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -233,7 +233,10 @@ def get_str_info(variant, proband, columns, ev_idx, pb_sex):
     var_dict["Repeat"] = variant[
         "shortTandemRepeatReferenceData"
     ]["repeatedSequence"]
+    # Get the repeat number from the JSON for one allele
     var_dict["STR1"] = num_copies(variant, pb_idx, 0)
+    # Get the repeat number from the JSON for the other allele 
+    # only if the STR is not in the X chromosome of a XY proband
     if var_dict["Chr"] in ["X"] and pb_sex == "MALE":
         var_dict["STR2"] = ""
     else:

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -633,7 +633,7 @@ class excel():
                 if event["tier"] in ["TIER1", "TIER2"]:
                     event_index = s_t_r["reportEvents"].index(event)
                     var_dict = var_info.get_str_info(
-                        s_t_r, self.proband, self.column_list, event_index
+                        s_t_r, self.proband, self.column_list, event_index, self.proband_sex
                     )
                     variant_list.append(var_dict)
 

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -321,6 +321,60 @@ class TestVariantInfo():
 
         assert result == expected_output_tier
 
+    def test_get_snv_info_hemizygous_str(self, variant=variant):
+        '''
+        Check that the function returns the expected output in the case of 
+        missing X STR count in XY proband.
+        '''
+
+        variant["variantCalls"] = [
+                {
+                    "participantId": "testPB",
+                    "numberOfCopies": [
+                        {"numberOfCopies": 8}
+                    ]
+                },
+                {
+                    "participantId": "testT2",
+                    "numberOfCopies": [
+                        {"numberOfCopies": 14},
+                        {"numberOfCopies": 16}
+                    ]
+                },
+                {
+                    "participantId": "testT3",
+                    "numberOfCopies": [
+                        {"numberOfCopies": 8}
+                    ]
+                }
+            ]
+        
+        proband = "testPB"
+        columns = ["Chr", "Pos", "End", "Length", "Type", "Priority", "Repeat", "STR1", "STR2", "Gene", "AF Max"]
+        ev_idx = 0
+
+        # Call the function to test with hemizygous proband
+        result = var_info.get_str_info(variant, proband, columns, ev_idx)
+
+        # Expected output for hemizygous proband
+        expected_output = var_info.add_columns_to_dict(columns)
+        expected_output.update({
+            "Chr": "12",
+            "Pos": 6936728,
+            "End": 6936773,
+            "Length": 45,
+            "Type": "STR",
+            "Priority": "TIER1_STR",
+            "Repeat": "CAG",
+            "STR1": 8,
+            "STR2": "",
+            "Gene": "SYMB1",
+            "AF Max": "-"
+        })
+
+        assert result == expected_output
+
+
     def test_tier_conversion(self):
         '''
         Test Tiers from JSON are converted into tier representation as desired

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -159,48 +159,51 @@ class TestInterpretationService():
 
 class TestVariantInfo():
 
-    variant = {
-            "coordinates": {
-                "chromosome": "12",
-                "start": 6936728,
-                "end": 6936773
-            },
-            "reportEvents": [
-                {
-                    "tier": "TIER1",
-                    "genomicEntities": [
-                        {
-                            "type": "gene",
-                            "geneSymbol": "SYMB1"
-                        }
-                    ]
+    @pytest.fixture
+    def mock_variant(self):
+        variant = {
+                "coordinates": {
+                    "chromosome": "12",
+                    "start": 6936728,
+                    "end": 6936773
                 },
-                {
-                    "tier": "TIER2",
-                    "genomicEntities": [
-                        {
-                            "type": "gene",
-                            "geneSymbol": "SYMB1"
-                        }
-                    ]
+                "reportEvents": [
+                    {
+                        "tier": "TIER1",
+                        "genomicEntities": [
+                            {
+                                "type": "gene",
+                                "geneSymbol": "SYMB1"
+                            }
+                        ]
+                    },
+                    {
+                        "tier": "TIER2",
+                        "genomicEntities": [
+                            {
+                                "type": "gene",
+                                "geneSymbol": "SYMB1"
+                            }
+                        ]
+                    }
+                ],
+                "shortTandemRepeatReferenceData": {
+                    "repeatedSequence": "CAG"
+                },
+                "variantCalls": [
+                    {
+                        "participantId": "testPB",
+                        "numberOfCopies": [
+                            {"numberOfCopies": 8},
+                            {"numberOfCopies": 16}
+                        ]
+                    }
+                ],
+                "variantAttributes": {
+                    "alleleFrequencies": ""
                 }
-            ],
-            "shortTandemRepeatReferenceData": {
-                "repeatedSequence": "CAG"
-            },
-            "variantCalls": [
-                {
-                    "participantId": "testPB",
-                    "numberOfCopies": [
-                        {"numberOfCopies": 8},
-                        {"numberOfCopies": 16}
-                    ]
-                }
-            ],
-            "variantAttributes": {
-                "alleleFrequencies": ""
             }
-        }
+        return variant
 
     '''
     Test variant info functions.
@@ -215,7 +218,7 @@ class TestVariantInfo():
             column_list
         ) == {"ColA": '', "ColB": ''}
 
-    def test_get_str_info_tier1(self, variant=variant):
+    def test_get_str_info_tier1(self, mock_variant):
     # Mock input data
         
         proband = "testPB"
@@ -240,14 +243,14 @@ class TestVariantInfo():
         })
 
         # Call the function to test for TEIR1
-        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
+        result = var_info.get_str_info(mock_variant, proband, columns, ev_idx, proband_sex)
 
         # Assertions
         assert result == expected_output
 
-    def test_get_str_info_tier2(self, variant=variant):
+    def test_get_str_info_tier2(self, mock_variant):
          # Modify the variant to replace reportEvents with TIER2 events
-        variant["reportEvents"] = [
+        mock_variant["reportEvents"] = [
             {
             "tier": "TIER2",
             "genomicEntities": [
@@ -265,7 +268,7 @@ class TestVariantInfo():
         proband_sex = "FEMALE"
 
         # Call the function to test for TIER2
-        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
+        result = var_info.get_str_info(mock_variant, proband, columns, ev_idx, proband_sex)
 
         # Expected output for TIER2 STR
         expected_output_tier = var_info.add_columns_to_dict(columns)
@@ -285,8 +288,8 @@ class TestVariantInfo():
 
         assert result == expected_output_tier
 
-    def test_get_str_info_tier_null(self, variant=variant):
-        variant["reportEvents"] = [
+    def test_get_str_info_tier_null(self, mock_variant):
+        mock_variant["reportEvents"] = [
             {
             "tier": "null",
             "genomicEntities": [
@@ -304,7 +307,7 @@ class TestVariantInfo():
         proband_sex = "MALE"
 
         # Call the function to test for null tier
-        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
+        result = var_info.get_str_info(mock_variant, proband, columns, ev_idx, proband_sex)
 
         # Expected output for null tier STR
         expected_output_tier = var_info.add_columns_to_dict(columns)
@@ -324,19 +327,19 @@ class TestVariantInfo():
 
         assert result == expected_output_tier
 
-    def test_get_str_info_hemizygous(self, variant=variant):
+    def test_get_str_info_hemizygous(self, mock_variant):
         '''
         Check that the function returns the expected output in the case of 
         missing X STR count in XY proband.
         '''
 
-        variant["coordinates"] = {
+        mock_variant["coordinates"] = {
                 "chromosome": "X",
                 "start": 6936728,
                 "end": 6936773
             }
         
-        variant["reportEvents"] = [
+        mock_variant["reportEvents"] = [
             {
             "tier": "TIER1",
             "genomicEntities": [
@@ -348,7 +351,7 @@ class TestVariantInfo():
             }
         ]
 
-        variant["variantCalls"] = [
+        mock_variant["variantCalls"] = [
                 {
                     "participantId": "testPB",
                     "numberOfCopies": [
@@ -376,7 +379,7 @@ class TestVariantInfo():
         proband_sex = "MALE"
 
         # Call the function to test with hemizygous proband
-        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
+        result = var_info.get_str_info(mock_variant, proband, columns, ev_idx, proband_sex)
 
         # Expected output for hemizygous proband
         expected_output = var_info.add_columns_to_dict(columns)

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -324,7 +324,7 @@ class TestVariantInfo():
 
         assert result == expected_output_tier
 
-    def test_get_snv_info_hemizygous_str(self, variant=variant):
+    def test_get_str_info_hemizygous(self, variant=variant):
         '''
         Check that the function returns the expected output in the case of 
         missing X STR count in XY proband.

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -221,6 +221,7 @@ class TestVariantInfo():
         proband = "testPB"
         columns = ["Chr", "Pos", "End", "Length", "Type", "Priority", "Repeat", "STR1", "STR2", "Gene", "AF Max"]
         ev_idx = 0
+        proband_sex = "MALE"
 
         # Expected output for TIER1 STR
         expected_output = var_info.add_columns_to_dict(columns)
@@ -239,7 +240,7 @@ class TestVariantInfo():
         })
 
         # Call the function to test for TEIR1
-        result = var_info.get_str_info(variant, proband, columns, ev_idx)
+        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
 
         # Assertions
         assert result == expected_output
@@ -261,9 +262,10 @@ class TestVariantInfo():
         proband = "testPB"
         columns = ["Chr", "Pos", "End", "Length", "Type", "Priority", "Repeat", "STR1", "STR2", "Gene", "AF Max"]
         ev_idx = 0
+        proband_sex = "FEMALE"
 
         # Call the function to test for TIER2
-        result = var_info.get_str_info(variant, proband, columns, ev_idx)
+        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
 
         # Expected output for TIER2 STR
         expected_output_tier = var_info.add_columns_to_dict(columns)
@@ -299,11 +301,12 @@ class TestVariantInfo():
         proband = "testPB"
         columns = ["Chr", "Pos", "End", "Length", "Type", "Priority", "Repeat", "STR1", "STR2", "Gene", "AF Max"]
         ev_idx = 0
+        proband_sex = "MALE"
 
-        # Call the function to test for TIER2
-        result = var_info.get_str_info(variant, proband, columns, ev_idx)
+        # Call the function to test for null tier
+        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
 
-        # Expected output for TIER2 STR
+        # Expected output for null tier STR
         expected_output_tier = var_info.add_columns_to_dict(columns)
         expected_output_tier.update({
             "Chr": "12",
@@ -326,6 +329,24 @@ class TestVariantInfo():
         Check that the function returns the expected output in the case of 
         missing X STR count in XY proband.
         '''
+
+        variant["coordinates"] = {
+                "chromosome": "X",
+                "start": 6936728,
+                "end": 6936773
+            }
+        
+        variant["reportEvents"] = [
+            {
+            "tier": "TIER1",
+            "genomicEntities": [
+                {
+                "type": "gene",
+                "geneSymbol": "SYMB1"
+                }
+            ]
+            }
+        ]
 
         variant["variantCalls"] = [
                 {
@@ -352,14 +373,15 @@ class TestVariantInfo():
         proband = "testPB"
         columns = ["Chr", "Pos", "End", "Length", "Type", "Priority", "Repeat", "STR1", "STR2", "Gene", "AF Max"]
         ev_idx = 0
+        proband_sex = "MALE"
 
         # Call the function to test with hemizygous proband
-        result = var_info.get_str_info(variant, proband, columns, ev_idx)
+        result = var_info.get_str_info(variant, proband, columns, ev_idx, proband_sex)
 
         # Expected output for hemizygous proband
         expected_output = var_info.add_columns_to_dict(columns)
         expected_output.update({
-            "Chr": "12",
+            "Chr": "X",
             "Pos": 6936728,
             "End": 6936773,
             "Length": 45,


### PR DESCRIPTION
An error was encountered during testing where hemizygous STRs (on X chromosome in XY proband) would crash as it tried to count the copies in the missing allele.

Included in the PR is:

- test for copy counting logic
- fixes to get_str_info and adding pb_sex as a parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/24)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of STR copy number representation for male probands on the X chromosome, ensuring accurate display of variant information.
- **Tests**
	- Updated existing tests to include the proband's sex when checking STR variant information.
	- Added a new test to verify correct behaviour for hemizygous STR variants on the X chromosome in male probands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->