### PR TITLE
DI-2257 HPO filtering

### DIFF
--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -252,20 +252,15 @@ class excel():
                 f"HPO version in JSON {version} not found in config\n"
                 f"{self.config}"
             )
-        # Get termPresence from JSON
-        term_presence = self.wgs_data[
-                    "interpretation_request_data"
-                ]['json_request']["pedigree"][
-            "members"
-            ][0]["hpoTermList"][0]['termPresence']
-
-        # If termPresence is unknown, remove variant from workbook
-        for k, v in filter(lambda item: item[1].get(term_presence, 'unknown') != "unknown", \
-        self.config['obos'].items()):
-            # process each variant if known
-            pass
 
         dxpy.download_dxfile(obo, "hpo.obo")
+
+    @staticmethod
+    def filter_hpo_terms(hpo_terms):
+        """Return HPO terms not marked as termPresence == 'unknown'."""
+        if not hpo_terms:
+            return []
+        return [t for t in hpo_terms if t.get('termPresence') != 'unknown']
 
     def get_hpo_terms(self, member):
         '''
@@ -290,6 +285,9 @@ class excel():
                 hpo_dict = graph.nodes[term]
                 hpo_name = hpo_dict['name']
                 hpo_names.append(hpo_name)
+            for i in member["hpoTermList"]:
+                if i.get("termPresence") != "unknown":
+                    hpo_terms.append(i["term"])
 
             hpo_names = '; '.join(hpo_names)
 
@@ -655,7 +653,7 @@ class excel():
             ][self.genome_data_format]["structuralVariants"]:
             for event in cnv["reportEvents"]:
                 event_index = cnv["reportEvents"].index(event)
-                # CNVs can be reported as Tier 1 ,Tier A, Tier 2 and Tier B 
+                # CNVs can be reported as Tier 1 ,Tier A, Tier 2 and Tier B
                 # GEL updated the nomenclature in 2024
                 if cnv["reportEvents"][event_index]["tier"] in [
                     "TIER1", "TIERA", "TIER2", "TIERB"
@@ -880,7 +878,7 @@ class excel():
         '''
         cnv = self.workbook.create_sheet(f"cnv_interpret_{cnv_sheet_num}")
         titles = {
-            "Intragenic CNVs should be analysed using SNV guidelines": [1,2], 
+            "Intragenic CNVs should be analysed using SNV guidelines": [1,2],
             "Chromosomal region/gene": [3, 2],
             "Start": [3, 3],
             "Stop": [3, 4],
@@ -897,17 +895,17 @@ class excel():
         }
 
         content = {
-            "Does the CNV contain protein coding genes? How many?": [8,2], 
-            "OMIM/green genes?": [9,2], 
-            "Any disease genes relevant to phenotype?": [10,2], 
-            "Are similar CNVs in the gnomAD-SV database? Or in DGV?": [12,2], 
+            "Does the CNV contain protein coding genes? How many?": [8,2],
+            "OMIM/green genes?": [9,2],
+            "Any disease genes relevant to phenotype?": [10,2],
+            "Are similar CNVs in the gnomAD-SV database? Or in DGV?": [12,2],
             "Does this CNV overlap with a known microdeletion or "
-            "microduplication syndrome? Check decipher, pubmed, new " 
-            "ACMG CNV guidelines Table S3": [14,2], 
+            "microduplication syndrome? Check decipher, pubmed, new "
+            "ACMG CNV guidelines Table S3": [14,2],
             "Similar CNVs in HGMD, decipher, pubmed listed as pathogenic?"
             "Are they de novo? Do they segregate with disease in the reported"
-            "family?": [16, 2], 
-            "Does gene of interest have evidence of HI/TS?": [17,2], 
+            "family?": [16, 2],
+            "Does gene of interest have evidence of HI/TS?": [17,2],
             "In this case is the CNV de novo, inherited, unknown? Good "
             "phenotype fit? Non-segregation in affected family"
             "members?": [19, 2],

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -252,6 +252,18 @@ class excel():
                 f"HPO version in JSON {version} not found in config\n"
                 f"{self.config}"
             )
+        # Get termPresence from JSON
+        term_presence = self.wgs_data[
+                    "interpretation_request_data"
+                ]['json_request']["pedigree"][
+            "members"
+            ][0]["hpoTermList"][0]['termPresence']
+
+        # If termPresence is unknown, remove variant from workbook
+        for k, v in filter(lambda item: item[1].get(term_presence, 'unknown') != "unknown", \
+        self.config['obos'].items()):
+            # process each variant if known
+            pass
 
         dxpy.download_dxfile(obo, "hpo.obo")
 

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -284,10 +284,7 @@ class excel():
             for term in hpo_terms:
                 hpo_dict = graph.nodes[term]
                 hpo_name = hpo_dict['name']
-                hpo_names.append(hpo_name)
-            for i in member["hpoTermList"]:
-                if i.get("termPresence") != "unknown":
-                    hpo_terms.append(i["term"])
+                hpo_names.append(hpo_name != "unknown")
 
             hpo_names = '; '.join(hpo_names)
 

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -43,7 +43,7 @@ class TestWorkbook():
                         },
                         {
                             'penetrance': 'incomplete',
-                            'specificDisease': 'OtherDisease'                   
+                            'specificDisease': 'OtherDisease'
                         }
                     ],
                     'analysisPanels': [
@@ -220,7 +220,7 @@ class TestVariantInfo():
 
     def test_get_str_info_tier1(self, mock_variant):
     # Mock input data
-        
+
         proband = "testPB"
         columns = ["Chr", "Pos", "End", "Length", "Type", "Priority", "Repeat", "STR1", "STR2", "Gene", "AF Max"]
         ev_idx = 0
@@ -545,3 +545,32 @@ class TestVariantNomenclature():
         assert var_info.look_up_id_in_refseq_mane_conversion_file(
             refseq_tsv, "ENST0000033", "ENSP"
         ) == "ENSP0000044"
+
+
+class TestHpoUnknownFiltering():
+    '''
+    Tests for HPO unknown filtering function when "termPresence" is "unknown"
+    '''
+    def test_hpo_unknown_filtering(self):
+        '''
+        Test that HPO terms with "termPresence" of "unknown" are filtered out
+        '''
+        hpo_terms = [
+            {
+                "hpoId": "HP:0004322",
+                "termPresence": "present"
+            },
+            {
+                "hpoId": "HP:0001249",
+                "termPresence": "unknown"
+            }
+        ]
+
+        filtered_terms = excel.filter_hpo_terms(hpo_terms)
+
+        assert filtered_terms == [
+            {
+                "hpoId": "HP:0004322",
+                "termPresence": "present"
+            }
+        ]

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -582,10 +582,4 @@ class TestHpoTerms():
         result = excel_instance.get_hpo_terms(member)
 
         # Should only include the "present" only
-        filtered_terms = [
-            {
-                "term": "HP:0004322",
-                "termPresence": "present"
-            }
-        ]
-        assert result == filtered_terms
+        assert result == [{"term": "HP:0004322", "termPresence": "present"}]

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -547,7 +547,7 @@ class TestVariantNomenclature():
         ) == "ENSP0000044"
 
 
-class TestHpoUnknownFiltering():
+class TestHpoTerms():
     '''
     Tests for HPO unknown filtering function when "termPresence" is "unknown"
     '''
@@ -582,4 +582,10 @@ class TestHpoUnknownFiltering():
         result = excel_instance.get_hpo_terms(member)
 
         # Should only include the "present" only
-        assert len(result) == 1
+        filtered_terms = [
+            {
+                "term": "HP:0004322",
+                "termPresence": "present"
+            }
+        ]
+        assert result == filtered_terms

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -329,7 +329,7 @@ class TestVariantInfo():
 
     def test_get_str_info_hemizygous(self, mock_variant):
         '''
-        Check that the function returns the expected output in the case of 
+        Check that the function returns the expected output in the case of
         missing X STR count in XY proband.
         '''
 
@@ -338,7 +338,7 @@ class TestVariantInfo():
                 "start": 6936728,
                 "end": 6936773
             }
-        
+
         mock_variant["reportEvents"] = [
             {
             "tier": "TIER1",
@@ -372,7 +372,7 @@ class TestVariantInfo():
                     ]
                 }
             ]
-        
+
         proband = "testPB"
         columns = ["Chr", "Pos", "End", "Length", "Type", "Priority", "Repeat", "STR1", "STR2", "Gene", "AF Max"]
         ev_idx = 0
@@ -403,7 +403,7 @@ class TestVariantInfo():
     def test_tier_conversion(self):
         '''
         Test Tiers from JSON are converted into tier representation as desired
-        by workbook. Workbook tiers should include the tier and the variant 
+        by workbook. Workbook tiers should include the tier and the variant
         type
         '''
         tiers_to_convert = [
@@ -439,7 +439,7 @@ class TestVariantInfo():
             ]
         }}
         assert var_info.get_af_max(variant) == '0.001'
-    
+
     def test_male_proband_X_SNV_is_hemizygous(self):
         '''
         Placeholder for testing male proband X SNV hemizygosity.
@@ -551,26 +551,35 @@ class TestHpoUnknownFiltering():
     '''
     Tests for HPO unknown filtering function when "termPresence" is "unknown"
     '''
-    def test_hpo_unknown_filtering(self):
+    @mock.patch('obonet.read_obo')
+    def test_hpo_unknown_filtering_in_get_hpo_terms(self, mock_obo):
         '''
-        Test that HPO terms with "termPresence" of "unknown" are filtered out
+        Test get_hpo_terms function filters out terms with "termPresence" of "unknown"
         '''
-        hpo_terms = [
-            {
-                "hpoId": "HP:0004322",
-                "termPresence": "present"
-            },
-            {
-                "hpoId": "HP:0001249",
-                "termPresence": "unknown"
-            }
-        ]
+        # Mock obo data
+        mock_graph = MagicMock()
+        mock_graph.nodes = {
+            "HP:0004322": {"name": "Short stature"},
+            "HP:0001249": {"name": "Intellectual disability"}
+        }
+        mock_obo.return_value = mock_graph
 
-        filtered_terms = excel.filter_hpo_terms(hpo_terms)
+        # Mock member data with mixed termPresence values
+        member = {
+            "hpoTermList": [
+                {
+                    "term": "HP:0004322",
+                    "termPresence": "present"
+                },
+                {
+                    "term": "HP:0001249",
+                    "termPresence": "unknown"
+                }
+            ]
+        }
 
-        assert filtered_terms == [
-            {
-                "hpoId": "HP:0004322",
-                "termPresence": "present"
-            }
-        ]
+        excel_instance = excel()
+        result = excel_instance.get_hpo_terms(member)
+
+        # Should only include the "present" only
+        assert len(result) == 1


### PR DESCRIPTION
Changes:
- Include HPO filtering and remove variants where 'termPresence' is unknown
- Added tests for HPO filtering

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/28)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workbook generation now excludes HPO entries marked as “unknown”, so exported phenotype lists contain only confirmed terms for clearer, more accurate reports.
  - Minor formatting clean-ups in CNV-related output paths (no change to user-visible behaviour).

- **Tests**
  - Added tests confirming HPO entries with status “unknown” are filtered out during processing, improving reliability of phenotype export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->