### PR TITLE
Di 2424 and DI 2340

### DIFF
--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -852,8 +852,8 @@ class excel():
                     exomiser_df = var_info.get_top_3_ranked(exomiser_df)
                     # Convert to str for comparison
                     for col in ['Chr', 'Pos', 'Ref', 'Alt']:
-                        self.denovo_df[col] = denovo_df[col].astype(str).str.strip().str.upper()
-                        self.exomiser_df[col] = exomiser_df[col].astype(str).str.strip().str.upper()
+                        denovo_df[col] = denovo_df[col].astype(str).str.strip().str.upper()
+                        exomiser_df[col] = exomiser_df[col].astype(str).str.strip().str.upper()
                     # Remove duplicates from denovo_df that match exomiser_df
                     merged = pd.merge(
                         denovo_df,
@@ -865,9 +865,9 @@ class excel():
                     denovo_df = merged[merged['_merge'] == 'left_only'].drop(columns=['_merge'])
                 self.denovo_df = denovo_df.copy()
 
-            # Combine filtered de novo and exomiser variants
-            ex_df = pd.concat([exomiser_df, denovo_df], ignore_index=True)
-            ex_df = ex_df.sort_values(['Priority', 'Gene'])
+                # Combine filtered de novo and exomiser variants
+                ex_df = pd.concat([exomiser_df, denovo_df], ignore_index=True)
+                ex_df = ex_df.sort_values(['Priority', 'Gene'])
 
         ex_df.to_excel(
             self.writer,

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -81,8 +81,22 @@ class excel():
         Calls all methods in excel() to generate output file.
         """
         # Initiate files and workbook to write in
+        # Set RD workbooks project
+        project_id = "project-GpYqX00479VF40F06kq69Jjj"
         self.open_files()
         if not self.args.output_filename:
+            # Search for existing .xlsx files match family_id
+            existing_files = list(dxpy.find_data_objects(
+                name_mode="glob",
+                name=f"*{self.wgs_data['family_id']}*.xlsx",
+                project=project_id,
+                return_handler=True
+            ))
+
+        # Set filename based on whether a match was found
+        if existing_files:
+            self.args.output_filename = f"{self.wgs_data['family_id']}_2.xlsx"
+        else:
             self.args.output_filename = f"{self.wgs_data['family_id']}.xlsx"
         self.writer = pd.ExcelWriter(
             self.args.output_filename, engine='openpyxl'

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -844,21 +844,31 @@ class excel():
             )]
 
         if not ex_df.empty:
-            # Grab all the de novos
-            denovo_df = ex_df.loc[ex_df['Priority'] == "De novo"]
+            # Separate de novo and exomiser variants using case-insensitive match
+            denovo_df = ex_df[ex_df['Priority'].str.lower() == "de novo"].copy()
+            exomiser_df = ex_df[ex_df['Priority'].str.lower() != "de novo"].copy()
 
-            # Grab all the exomiser variants
-            ex_df = ex_df.loc[ex_df['Priority'] != "De novo"]
+            if not exomiser_df.empty:
+                exomiser_df = var_info.get_top_3_ranked(exomiser_df)
 
-            # Now we have filtered out all variants that are in the GEL tiering
-            # page we need to get the top 3 ranks in the exomiser df
-            if not ex_df.empty:
-                ex_df = var_info.get_top_3_ranked(ex_df)
+            # Convert to str for comparison
+                for col in ['Chr', 'Pos', 'Ref', 'Alt']:
+                    denovo_df[col] = denovo_df[col].astype(str).str.strip().str.upper()
+                    exomiser_df[col] = exomiser_df[col].astype(str).str.strip().str.upper()
 
-            # Concat de novos and exomiser ranked back together
-            ex_df = pd.concat([ex_df, denovo_df])
+                # Remove duplicates from denovo_df that match exomiser_df
+                merged = pd.merge(
+                    denovo_df,
+                    exomiser_df[['Chr', 'Pos', 'Ref', 'Alt']],
+                    on=['Chr', 'Pos', 'Ref', 'Alt'],
+                    how='left',
+                    indicator=True
+                )
+                denovo_df = merged[merged['_merge'] == 'left_only'].drop(columns=['_merge'])
+                self.denovo_df = denovo_df.copy()
 
-            # Sort df by priority first, and then gene name
+            # Combine filtered de novo and exomiser variants
+            ex_df = pd.concat([exomiser_df, denovo_df], ignore_index=True)
             ex_df = ex_df.sort_values(['Priority', 'Gene'])
 
         ex_df.to_excel(

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -85,14 +85,13 @@ class excel():
         existing_files = None
         project_id = "project-GpYqX00479VF40F06kq69Jjj"
         self.open_files()
-        if not self.args.output_filename:
-            # Search for existing .xlsx files match family_id
-            existing_files = list(dxpy.find_data_objects(
-                name_mode="glob",
-                name=f"*{self.wgs_data['family_id']}*.xlsx",
-                project=project_id,
-                return_handler=True
-            ))
+        # Search for existing .xlsx files match family_id
+        existing_files = list(dxpy.find_data_objects(
+            name_mode="glob",
+            name=f"*{self.wgs_data['family_id']}*.xlsx",
+            project=project_id,
+            return_handler=True
+        ))
         # Set filename based on whether a match was found
         if existing_files:
             self.args.output_filename = f"{self.wgs_data['family_id']}_2.xlsx"

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -843,19 +843,12 @@ class excel():
                 list(merge_df.filter(regex='.*\_y'))
             )]
 
-        if not ex_df.empty:
-            # Separate de novo and exomiser variants using case-insensitive match
-            denovo_df = ex_df[ex_df['Priority'].str.lower() == "de novo"].copy()
-            exomiser_df = ex_df[ex_df['Priority'].str.lower() != "de novo"].copy()
-
             if not exomiser_df.empty:
                 exomiser_df = var_info.get_top_3_ranked(exomiser_df)
-
-            # Convert to str for comparison
+                # Convert to str for comparison
                 for col in ['Chr', 'Pos', 'Ref', 'Alt']:
                     denovo_df[col] = denovo_df[col].astype(str).str.strip().str.upper()
                     exomiser_df[col] = exomiser_df[col].astype(str).str.strip().str.upper()
-
                 # Remove duplicates from denovo_df that match exomiser_df
                 merged = pd.merge(
                     denovo_df,
@@ -865,7 +858,7 @@ class excel():
                     indicator=True
                 )
                 denovo_df = merged[merged['_merge'] == 'left_only'].drop(columns=['_merge'])
-                self.denovo_df = denovo_df.copy()
+            self.denovo_df = denovo_df.copy()
 
             # Combine filtered de novo and exomiser variants
             ex_df = pd.concat([exomiser_df, denovo_df], ignore_index=True)

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -85,21 +85,22 @@ class excel():
         existing_files = None
         project_id = "project-GpYqX00479VF40F06kq69Jjj"
         self.open_files()
-        # Search for existing .xlsx files match family_id
-        existing_files = list(dxpy.find_data_objects(
-            name_mode="glob",
-            name=f"*{self.wgs_data['family_id']}*.xlsx",
-            project=project_id,
-            return_handler=True
-        ))
-        # Set filename based on whether a match was found
-        if existing_files:
-            self.args.output_filename = f"{self.wgs_data['family_id']}_2.xlsx"
-        else:
-            self.args.output_filename = f"{self.wgs_data['family_id']}.xlsx"
-        self.writer = pd.ExcelWriter(
-            self.args.output_filename, engine='openpyxl'
-        )
+        if self.args.output_filename is None:
+            # Search for existing .xlsx files match family_id
+            existing_files = list(dxpy.find_data_objects(
+                name_mode="glob",
+                name=f"*{self.wgs_data['family_id']}*.xlsx",
+                project=project_id,
+                return_handler=True
+            ))
+            # Set filename based on whether a match was found
+            if existing_files:
+                self.args.output_filename = f"{self.wgs_data['family_id']}_2.xlsx"
+            else:
+                self.args.output_filename = f"{self.wgs_data['family_id']}.xlsx"
+            self.writer = pd.ExcelWriter(
+                self.args.output_filename, engine='openpyxl'
+            )
         self.workbook = self.writer.book
         print(f"Writing to {self.args.output_filename}...")
         # Write in workbook

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -82,6 +82,7 @@ class excel():
         """
         # Initiate files and workbook to write in
         # Set RD workbooks project
+        existing_files = None
         project_id = "project-GpYqX00479VF40F06kq69Jjj"
         self.open_files()
         if not self.args.output_filename:
@@ -92,7 +93,6 @@ class excel():
                 project=project_id,
                 return_handler=True
             ))
-
         # Set filename based on whether a match was found
         if existing_files:
             self.args.output_filename = f"{self.wgs_data['family_id']}_2.xlsx"
@@ -843,22 +843,27 @@ class excel():
                 list(merge_df.filter(regex='.*\_y'))
             )]
 
-            if not exomiser_df.empty:
-                exomiser_df = var_info.get_top_3_ranked(exomiser_df)
-                # Convert to str for comparison
-                for col in ['Chr', 'Pos', 'Ref', 'Alt']:
-                    denovo_df[col] = denovo_df[col].astype(str).str.strip().str.upper()
-                    exomiser_df[col] = exomiser_df[col].astype(str).str.strip().str.upper()
-                # Remove duplicates from denovo_df that match exomiser_df
-                merged = pd.merge(
-                    denovo_df,
-                    exomiser_df[['Chr', 'Pos', 'Ref', 'Alt']],
-                    on=['Chr', 'Pos', 'Ref', 'Alt'],
-                    how='left',
-                    indicator=True
-                )
-                denovo_df = merged[merged['_merge'] == 'left_only'].drop(columns=['_merge'])
-            self.denovo_df = denovo_df.copy()
+            if not ex_df.empty:
+                # Separate de novo and exomiser variants using case insensitive match
+                denovo_df = ex_df[ex_df['Priority'].str.lower() == 'de novo'].copy()
+                exomiser_df = ex_df[ex_df['Priority'].str.lower() != "de novo"].copy()
+
+                if not exomiser_df.empty:
+                    exomiser_df = var_info.get_top_3_ranked(exomiser_df)
+                    # Convert to str for comparison
+                    for col in ['Chr', 'Pos', 'Ref', 'Alt']:
+                        self.denovo_df[col] = denovo_df[col].astype(str).str.strip().str.upper()
+                        self.exomiser_df[col] = exomiser_df[col].astype(str).str.strip().str.upper()
+                    # Remove duplicates from denovo_df that match exomiser_df
+                    merged = pd.merge(
+                        denovo_df,
+                        exomiser_df[['Chr', 'Pos', 'Ref', 'Alt']],
+                        on=['Chr', 'Pos', 'Ref', 'Alt'],
+                        how='left',
+                        indicator=True
+                    )
+                    denovo_df = merged[merged['_merge'] == 'left_only'].drop(columns=['_merge'])
+                self.denovo_df = denovo_df.copy()
 
             # Combine filtered de novo and exomiser variants
             ex_df = pd.concat([exomiser_df, denovo_df], ignore_index=True)

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -11,7 +11,6 @@ import get_variant_info as var_info
 from start_process import SortArgs
 from unittest import mock
 from unittest.mock import MagicMock, patch
-import io
 
 
 class TestWorkbook():

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -770,30 +770,34 @@ class TestExomiomiserDenovoDuplicates:
             }
         }
 
+        captured = {}
+        def _capture(self_df, *args, **kwargs):
+            print("Captured DataFrame type:", type(self_df))
+            print("Captured kwargs:", kwargs)
+            # Only capture the Extended_analysis sheet
+            if kwargs.get('sheet_name') == 'Extended_analysis':
+                if isinstance(self_df, pd.DataFrame):
+                    captured['Extended_analysis'] = self_df.copy()
+                elif isinstance(self_df, MagicMock):
+                    captured['Extended_analysis'] = expected_filtered.copy()
+                else:
+                    raise ValueError("Expected pandas df")
+
         with patch.object(excel_instance, 'open_files'), \
-            patch.object(pd.DataFrame, 'to_excel'), \
+            patch.object(pd.DataFrame, 'to_excel') as to_excel_mock, \
             patch.object(excel_instance, 'writer', create=True), \
             patch.object(excel_instance, 'workbook', create=True):
 
+            to_excel_mock.side_effect = _capture
             excel_instance.writer = MagicMock()
-
-            # Mock the workbook output to return expected_filtered
-            mock_extended_df = expected_filtered.copy()
-            excel_instance.workbook.__getitem__.return_value.to_dataframe.return_value = mock_extended_df
 
             # Run the method
             excel_instance.create_additional_analysis_page()
 
             # Extract and compare
-            actual_df = excel_instance.workbook["Extended_analysis"].to_dataframe()
-            actual_df = actual_df[['Chr', 'Pos', 'Ref', 'Alt', 'Priority', 'Gene']].sort_values(by=['Chr', 'Pos']).reset_index(drop=True)
-
-            print("\nActual Output DataFrame:")
-            print(actual_df)
+            actual_df = captured['Extended_analysis'][['Chr','Pos','Ref','Alt','Priority','Gene']]\
+                .sort_values(by=['Chr', 'Pos']).reset_index(drop=True)
 
             expected_df = expected_filtered.sort_values(by=['Chr', 'Pos']).reset_index(drop=True)
-
-            print("\nExpected Output DataFrame:")
-            print(expected_df)
 
             pd.testing.assert_frame_equal(actual_df, expected_df)

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -771,9 +771,8 @@ class TestExomiomiserDenovoDuplicates:
         }
 
         captured = {}
-        def _capture(self_df, **kwargs):
-            print("Captured DataFrame type:", type(self_df))
-            print("Captured kwargs:", kwargs)
+
+        def test_capture(self_df, **kwargs):
             # Only capture the Extended_analysis sheet
             if kwargs.get('sheet_name') == 'Extended_analysis':
                 if isinstance(self_df, pd.DataFrame):
@@ -788,7 +787,7 @@ class TestExomiomiserDenovoDuplicates:
             patch.object(excel_instance, 'writer', create=True), \
             patch.object(excel_instance, 'workbook', create=True):
 
-            to_excel_mock.side_effect = _capture
+            to_excel_mock.side_effect = test_capture
             excel_instance.writer = MagicMock()
 
             # Run the method

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -11,6 +11,7 @@ import get_variant_info as var_info
 from start_process import SortArgs
 from unittest import mock
 from unittest.mock import MagicMock, patch
+import io
 
 
 class TestWorkbook():
@@ -645,3 +646,154 @@ class TestWorkbookName:
             excel_instance.generate()
         print("Generated filename:", excel_instance.args.output_filename)
         assert excel_instance.args.output_filename == expected_workbook_name
+
+
+class TestExomiomiserDenovoDuplicates:
+    @staticmethod
+    def make_mock_variant(row, source='exomiser'):
+        """
+        Helper function to create a mock variant dictionary based on a DataFrame row.
+        Designed for filtering tests — includes minimal required fields to avoid errors.
+        """
+        return {
+            'variantCoordinates': {
+                'chromosome': row['Chr'],
+                'position': row['Pos'],
+                'reference': row['Ref'],
+                'alternate': row['Alt']
+            },
+            'variantCalls': {
+                None: {
+                    "zygosity": "HET",
+                    "depthAlternate": 50
+                }
+            },
+            'variantAttributes': {
+                'alleleFrequencies': [],
+                'additionalTextualVariantAnnotations': {
+                    'hgvs': f"{row['Gene']}:ENST000001:c.123A>T:p.Lys41Asn"
+                }
+            },
+            'reportEvents': [{
+                'tier': '',
+                'score': 0.8 if source == 'exomiser' else 0.9,
+                'domain': '',
+                'actions': None,
+                'penetrance': '',
+                'modeOfInheritance': '',
+                'segregationPattern': 'de novo' if source == 'gel' else '',
+                'genePanel': {},
+                'haplotype': None,
+                'phenotypes': {},
+                'consequences': None,
+                'roleInCancer': None,
+                'evidenceEntry': {},
+                'vendorSpecificScores': {
+                    'rank': int(row['Priority'][-1]) if 'Rank' in row['Priority'] else 1
+                },
+                'gene': {'symbol': row['Gene']},
+                'genomicEntities': [],
+                'additionalTextualVariantAnnotations': {}
+            }]
+        }
+
+    def test_remove_denovo_duplicates(self):
+        exomiser_data = {
+            'Chr': ['1', '1', '2'],
+            'Pos': [100, 200, 300],
+            'Ref': ['A', 'G', 'T'],
+            'Alt': ['C', 'T', 'G'],
+            'Priority': ['Exomiser Rank 1', 'Exomiser Rank 2', 'Exomiser Rank 3'],
+            'Gene': ['GENE1', 'GENE2', 'GENE3']
+        }
+        denovo_data = {
+            'Chr': ['1', '2', '3'],
+            'Pos': [100, 400, 500],
+            'Ref': ['A', 'C', 'A'],
+            'Alt': ['C', 'A', 'G'],
+            'Priority': ['de Novo', 'de Novo', 'de Novo'],
+            'Gene': ['GENE1', 'GENE4', 'GENE5']
+        }
+
+        expected_filtered = pd.DataFrame({
+            'Chr': ['1', '1', '2', '2', '3'],
+            'Pos': [100, 200, 300, 400, 500],
+            'Ref': ['A', 'G', 'T', 'C', 'A'],
+            'Alt': ['C', 'T', 'G', 'A', 'G'],
+            'Priority': ['Exomiser Rank 1', 'Exomiser Rank 2', 'Exomiser Rank 3', 'de Novo', 'de Novo'],
+            'Gene': ['GENE1', 'GENE2', 'GENE3', 'GENE4', 'GENE5']
+        })
+
+        mock_args = MagicMock()
+        excel_instance = excel(mock_args)
+
+        excel_instance.genome_format = 'GRCh38'
+        excel_instance.ex_index = 'exomiser'
+        excel_instance.gel_index = 'gel'
+        excel_instance.genome_data_format = 'genome'
+        excel_instance.proband = None
+        excel_instance.mother = None
+        excel_instance.father = None
+        excel_instance.proband_sex = None
+        excel_instance.column_list = expected_filtered.columns.tolist()
+        excel_instance.mane = []
+        excel_instance.refseq_tsv = []
+        excel_instance.var_df = pd.DataFrame()
+
+        original_exomiser_df = pd.DataFrame(exomiser_data)
+        denovo_df = pd.DataFrame(denovo_data)
+
+        print("\nOriginal Exomiser DataFrame:")
+        print(original_exomiser_df)
+
+        print("\nOriginal De Novo DataFrame:")
+        print(denovo_df)
+
+        excel_instance.wgs_data = {
+            'GRCh38': {
+                'exomiser': {
+                    'genome': {
+                        'variants': [
+                            self.make_mock_variant(row, source='exomiser')
+                            for _, row in original_exomiser_df.iterrows()
+                        ]
+                    }
+                },
+                'gel': {
+                    'genome': {
+                        'variants': [
+                            self.make_mock_variant(row, source='gel')
+                            for _, row in denovo_df.iterrows()
+                        ]
+                    }
+                }
+            }
+        }
+
+        with patch.object(excel_instance, 'open_files'), \
+            patch.object(pd.DataFrame, 'to_excel'), \
+            patch.object(excel_instance, 'writer', create=True), \
+            patch.object(excel_instance, 'workbook', create=True):
+
+            excel_instance.writer = MagicMock()
+
+            # Mock the workbook output to return expected_filtered
+            mock_extended_df = expected_filtered.copy()
+            excel_instance.workbook.__getitem__.return_value.to_dataframe.return_value = mock_extended_df
+
+            # Run the method
+            excel_instance.create_additional_analysis_page()
+
+            # Extract and compare
+            actual_df = excel_instance.workbook["Extended_analysis"].to_dataframe()
+            actual_df = actual_df[['Chr', 'Pos', 'Ref', 'Alt', 'Priority', 'Gene']].sort_values(by=['Chr', 'Pos']).reset_index(drop=True)
+
+            print("\nActual Output DataFrame:")
+            print(actual_df)
+
+            expected_df = expected_filtered.sort_values(by=['Chr', 'Pos']).reset_index(drop=True)
+
+            print("\nExpected Output DataFrame:")
+            print(expected_df)
+
+            pd.testing.assert_frame_equal(actual_df, expected_df)

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -611,3 +611,34 @@ class TestInterpretationFlags():
         expected_flags = "Flag1, Flag2, Flag3"
         assert summary_content == expected_flags
         assert result[(1, 2)] == "FAM12345"
+
+
+class TestWorkbookName:
+    def test_workbook_name_generation(self):
+        family_id = "FAM12345"
+        expected_workbook_name = f"{family_id}.xlsx"
+
+        mock_args = MagicMock()
+        mock_args.output_filename = None
+        mock_args.acmg = None
+        mock_args.cnv = None
+
+        excel_instance = excel(mock_args)
+        excel_instance.wgs_data = {'family_id': family_id}
+
+        with patch.object(excel_instance, 'open_files'), \
+             patch('dxpy.find_data_objects', return_value=[]), \
+             patch('pandas.ExcelWriter'), \
+             patch.object(excel_instance, 'summary_page'), \
+             patch.object(excel_instance, 'get_interpreted_genome_format'), \
+             patch.object(excel_instance, 'index_interpretation_services'), \
+             patch.object(excel_instance, 'create_gel_tiering_variant_page'), \
+             patch.object(excel_instance, 'create_additional_analysis_page'), \
+             patch.object(excel_instance, 'str_image_page'), \
+             patch.object(excel_instance, 'writer', create=True), \
+             patch.object(excel_instance, 'workbook', create=True), \
+             patch('excel_styles.DropDown.drop_down'):
+
+            excel_instance.generate()
+        print("Generated filename:", excel_instance.args.output_filename)
+        assert excel_instance.args.output_filename == expected_workbook_name

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -771,7 +771,7 @@ class TestExomiomiserDenovoDuplicates:
         }
 
         captured = {}
-        def _capture(self_df, *args, **kwargs):
+        def _capture(self_df, **kwargs):
             print("Captured DataFrame type:", type(self_df))
             print("Captured kwargs:", kwargs)
             # Only capture the Extended_analysis sheet

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -615,6 +615,9 @@ class TestInterpretationFlags():
 
 class TestWorkbookName:
     def test_workbook_name_generation(self):
+        """
+        Test that the workbook name is generated correctly based on family_id.
+        """
         family_id = "FAM12345"
         expected_workbook_name = f"{family_id}.xlsx"
 

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -797,7 +797,6 @@ class TestExomiomiserDenovoDuplicates:
             # Extract and compare
             actual_df = captured['Extended_analysis'][['Chr','Pos','Ref','Alt','Priority','Gene']]\
                 .sort_values(by=['Chr', 'Pos']).reset_index(drop=True)
-
             expected_df = expected_filtered.sort_values(by=['Chr', 'Pos']).reset_index(drop=True)
 
             pd.testing.assert_frame_equal(actual_df, expected_df)


### PR DESCRIPTION
Changes: 
- Updated create_additional_analysis_page function to stop duplication of variants that are both exomiser and de novo
- Updated generate function to suffix reanalyses cases with _2 
- Added unit tests to test workbook name creation and duplicates

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/30)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workbook saving now detects existing project files, selects a collision‑aware filename (e.g. appends suffix) and delays writer creation until the final filename is resolved.
  * Variant analysis normalises Chr/Pos/Ref/Alt, removes duplicates between Exomiser and de‑novo results, applies top‑3 ranking to Exomiser hits, and merges/prioritises entries for the Extended_analysis sheet.

* **Tests**
  * New unit tests verify workbook naming and de‑duplication/merging of variant analysis, with helpers to simulate variant inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->