### PR TITLE
DI-2429

### DIFF
--- a/resources/home/dnanexus/excel_styles.py
+++ b/resources/home/dnanexus/excel_styles.py
@@ -3,7 +3,6 @@ from openpyxl.styles import Alignment, Border, DEFAULT_FONT, Font, Side
 from openpyxl.styles.fills import PatternFill
 from openpyxl.worksheet.datavalidation import DataValidation
 from openpyxl import load_workbook
-from openpyxl.styles import Border, Side
 from copy import copy
 
 # openpyxl style settings

--- a/resources/home/dnanexus/excel_styles.py
+++ b/resources/home/dnanexus/excel_styles.py
@@ -3,6 +3,8 @@ from openpyxl.styles import Alignment, Border, DEFAULT_FONT, Font, Side
 from openpyxl.styles.fills import PatternFill
 from openpyxl.worksheet.datavalidation import DataValidation
 from openpyxl import load_workbook
+from openpyxl.styles import Border, Side
+from copy import copy
 
 # openpyxl style settings
 THIN = Side(border_style="thin", color="000000")
@@ -45,7 +47,7 @@ class ExcelStyles():
                 for cells in sheet[row]:
                     for cell in cells:
                         # border style is immutable => copy current and modify
-                        cell_border = cell.border.copy()
+                        cell_border = copy(cell.border)
                         if side == 'horizontal':
                             cell_border.top = THIN
                         if side == 'horizontal_thick':

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -13,6 +13,7 @@ from os import path
 from pathlib import Path
 import re
 import dxpy
+from openpyxl.styles import PatternFill
 
 from excel_styles import ExcelStyles, DropDown
 import get_variant_info as var_info
@@ -637,6 +638,8 @@ class excel():
                         self.father,
                         self.proband_sex
                         )
+                    if var_dict.get("Zygosity") == "alternate_homozygous":
+                        var_dict["Zygosity"] = "homozygous"
                     c_dot, p_dot = var_info.get_hgvs_gel(
                         snv,
                         self.mane,
@@ -1012,6 +1015,10 @@ class excel():
             cnv[f"G{row}"].alignment = Alignment(
                 wrapText=True, vertical="center", horizontal="center"
             )
+        # Implement colour labelling
+        yellow_fill = PatternFill(start_color="FFFF00", end_color="FFFF00", fill_type="solid")
+        for row in range(1, cnv.max_row + 1):
+            cnv[f"H{row}"].fill = yellow_fill
 
     def write_snv_reporting_template(self, report_sheet_num) -> None:
         """
@@ -1207,3 +1214,13 @@ class excel():
             ]
         }
         ExcelStyles.borders(self, row_ranges, report)
+
+        # Implement colour labelling
+        # Adding yellow to Column M (checker comments column)
+        yellow_fill = PatternFill(start_color="FFFF00", end_color="FFFF00", fill_type="solid")
+        for row in range(1, report.max_row + 1):
+            report[f"M{row}"].fill = yellow_fill
+
+        # Adding yellow to G2 and G3 (Transcripts/IGV checked column)
+        report["G2"].fill = yellow_fill
+        report["G3"].fill = yellow_fill

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -28,7 +28,7 @@ class TestWorkbook():
         }
     }
     wgs_data = {
-        "family_id": "r12345",
+        "family_id": ["r12345"],
         "interpretation_request_data": {
             "json_request": {
                 "pedigree": {
@@ -37,30 +37,81 @@ class TestWorkbook():
                             "hpoTermList": [
                                 {"hpoBuildNumber": "vXXXXXX"}
                             ]
-                        }
-                    ],
-                    'diseasePenetrances': [
-                        {
-                            'penetrance': 'complete',
-                            'specificDisease': 'Congenital malformation'
                         },
                         {
-                            'penetrance': 'incomplete',
-                            'specificDisease': 'OtherDisease'
+                            "participantId": "proband_id",
+                            "sex": "MALE",
+                            "isProband": True
                         }
                     ],
-                    'analysisPanels': [
+                    "diseasePenetrances": [
                         {
-                            'panelId': "486",
-                            'panelName': "286",
-                            'specificDisease': 'Congenital malformation',
-                            'panelVersion': "2.2"
+                            "penetrance": "complete",
+                            "specificDisease": "Congenital malformation"
+                        },
+                        {
+                            "penetrance": "incomplete",
+                            "specificDisease": "OtherDisease"
+                        }
+                    ],
+                    "analysisPanels": [
+                        {
+                            "panelId": "486",
+                            "panelName": "286",
+                            "specificDisease": "Congenital malformation",
+                            "panelVersion": "2.2"
                         }
                     ]
                 }
             }
-        }
+        },
+        "interpretedGenomes": [
+            {
+                "interpretedGenomeData": {
+                    "interpretationService": "genomics_england_tiering",
+                    "variants": [
+                        {
+                            "variantCoordinates": {
+                                "chromosome": "1",
+                                "position": 12345,
+                                "reference": "A",
+                                "alternate": "G"
+                            },
+                            "variantCalls": [
+                                {
+                                    "participantId": "proband_id",
+                                    "zygosity": "alternate_homozygous",
+                                    "depthReference": 20,
+                                    "depthAlternate": 29
+                                }
+                            ],
+                            "variantAttributes": {
+                                "alleleFrequencies": [],
+                                "additionalTextualVariantAnnotations": {
+                                    "hgvs": ["TEST:c.123A>G"]
+                                },
+                                "cdnaChanges": ["TEST:c.123A>G"],
+                                "proteinChanges": ["TEST:p.Arg123Gly"]
+                            },
+                            "reportEvents": [
+                                {
+                                    "tier": "TIER1",
+                                    "genomicEntities": [
+                                        {"geneSymbol": "TESTGENE", "type": "gene"}
+                                    ],
+                                    "penetrance": "incomplete",
+                                    "modeOfInheritance": "None"
+                                }
+                            ]
+                        }
+                    ],
+                    "shortTandemRepeats": [],
+                    "structuralVariants": []
+                }
+            }
+        ]
     }
+
 
     def test_get_panels_extracts_data_from_input_panel_json(self):
         '''
@@ -106,73 +157,11 @@ class TestWorkbook():
         Test that 'alternate_homozygous' notation in zygosity is converted to
         'homozygous' in the workbook
         """
-        # Mock GEL-tiered SNV with all fields needed
-        mock_wgs_data = {
-            "family_id": "FAM123",
-            "interpretation_request_data": {
-                "json_request": {
-                    "pedigree": {
-                        "members": [
-                            {
-                                "participantId": "proband_id",
-                                "sex": "MALE",
-                                "isProband": True,
-                            }
-                        ]
-                    }
-                }
-            },
-            "interpretedGenomes": [
-                {
-                    "interpretedGenomeData": {
-                        "interpretationService": "genomics_england_tiering",
-                        "variants": [
-                            {
-                                "variantCoordinates": {
-                                    "chromosome": "1",
-                                    "position": 12345,
-                                    "reference": "A",
-                                    "alternate": "G",
-                                },
-                                "variantCalls": [
-                                    {
-                                        "participantId": "proband_id",
-                                        "zygosity": "alternate_homozygous",
-                                        "depthReference": 20,
-                                        "depthAlternate": 29,
-                                    }
-                                ],
-                                "variantAttributes": {
-                                    "alleleFrequencies": [],
-                                    "additionalTextualVariantAnnotations": {
-                                        "hgvs": ["TEST:c.123A>G"]
-                                    },
-                                    "cdnaChanges": ["TEST:c.123A>G"],
-                                    "proteinChanges": ["TEST:p.Arg123Gly"],
-                                },
-                                "reportEvents": [
-                                    {
-                                        "tier": "TIER1",
-                                        "genomicEntities": [
-                                            {"geneSymbol": "TESTGENE", "type": "gene"}
-                                        ],
-                                        "penetrance": "incomplete",
-                                        "modeOfInheritance": "None"
-                                    }
-                                ],
-                            }
-                        ],
-                        "shortTandemRepeats": [],
-                        "structuralVariants": []
-                    }
-                }
-            ],
-        }
 
         # Set up excel instance with mocked dependencies
         mock_args = MagicMock()
         excel_instance = excel(mock_args)
-        excel_instance.wgs_data = mock_wgs_data
+        excel_instance.wgs_data = self.wgs_data
         excel_instance.proband = "proband_id"
         excel_instance.proband_sex = "MALE"
         excel_instance.mane = []

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -7,6 +7,7 @@ import obonet
 import sys
 import json
 import warnings
+import excel_styles
 from openpyxl import Workbook
 from make_workbook import excel
 import get_variant_info as var_info
@@ -101,17 +102,104 @@ class TestWorkbook():
             excel.add_epic_data(self)
 
     def test_alternative_homozygous_notation_becomes_homozygous(self):
-        '''
-        Test that 'alternative_homozgyous' notation in zygosity is converted to
+        """
+        Test that 'alternate_homozygous' notation in zygosity is converted to
         'homozygous' in the workbook
-        '''
-        df = pd.DataFrame([{"Zygosity": "alternate_homozygous"}])
-        print(df)
-        df.loc[df["Zygosity"] == "alternate_homozygous", "Zygosity"] = "homozygous"
-        print("DataFrame after conversion:", df)
+        """
+        # Mock GEL-tiered SNV with all fields needed
+        mock_wgs_data = {
+            "family_id": "FAM123",
+            "interpretation_request_data": {
+                "json_request": {
+                    "pedigree": {
+                        "members": [
+                            {
+                                "participantId": "proband_id",
+                                "sex": "MALE",
+                                "isProband": True,
+                            }
+                        ]
+                    }
+                }
+            },
+            "interpretedGenomes": [
+                {
+                    "interpretedGenomeData": {
+                        "interpretationService": "genomics_england_tiering",
+                        "variants": [
+                            {
+                                "variantCoordinates": {
+                                    "chromosome": "1",
+                                    "position": 12345,
+                                    "reference": "A",
+                                    "alternate": "G",
+                                },
+                                "variantCalls": [
+                                    {
+                                        "participantId": "proband_id",
+                                        "zygosity": "alternate_homozygous",
+                                        "depthReference": 20,
+                                        "depthAlternate": 29,
+                                    }
+                                ],
+                                "variantAttributes": {
+                                    "alleleFrequencies": [],
+                                    "additionalTextualVariantAnnotations": {
+                                        "hgvs": ["TEST:c.123A>G"]
+                                    },
+                                    "cdnaChanges": ["TEST:c.123A>G"],
+                                    "proteinChanges": ["TEST:p.Arg123Gly"],
+                                },
+                                "reportEvents": [
+                                    {
+                                        "tier": "TIER1",
+                                        "genomicEntities": [
+                                            {"geneSymbol": "TESTGENE", "type": "gene"}
+                                        ],
+                                        "penetrance": "incomplete",
+                                        "modeOfInheritance": "None"
+                                    }
+                                ],
+                            }
+                        ],
+                        "shortTandemRepeats": [],
+                        "structuralVariants": []
+                    }
+                }
+            ],
+        }
 
-        assert "homozygous" in df["Zygosity"].values
-        assert "alternative_homozygous" not in df["Zygosity"].values
+        # Set up excel instance with mocked dependencies
+        mock_args = MagicMock()
+        excel_instance = excel(mock_args)
+        excel_instance.wgs_data = mock_wgs_data
+        excel_instance.proband = "proband_id"
+        excel_instance.proband_sex = "MALE"
+        excel_instance.mane = []
+        excel_instance.refseq_tsv = []
+        excel_instance.var_df = pd.DataFrame()
+
+        # Call helper fnctions that performs normalisation
+        excel_instance.get_interpreted_genome_format()
+        excel_instance.index_interpretation_services()
+
+        # Patch whats needed for the excel_instance
+        with patch.object(pd.DataFrame, "to_excel", return_value=None), \
+            patch.object(excel_instance, "open_files"), \
+            patch.object(excel_instance, "writer", create=True), \
+            patch.object(excel_instance, "workbook", create=True), \
+            patch("excel_styles.DropDown.drop_down"), \
+            patch("excel_styles.ExcelStyles.borders"):
+
+            excel_instance.writer = MagicMock()
+            excel_instance.workbook = MagicMock()
+
+            # Call function that changes"alternate_homozygous" to "homozygous"
+            excel_instance.create_gel_tiering_variant_page()
+
+            # Check alternate_homozygous changed to homozygous in mock workbook
+            assert "homozygous" in excel_instance.var_df["Zygosity"].values
+            assert "alternate_homozygous" not in excel_instance.var_df["Zygosity"].values
 
     def test_write_snv_report_colouring(self):
         '''

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -6,6 +6,8 @@ import os
 import obonet
 import sys
 import json
+import warnings
+from openpyxl import Workbook
 from make_workbook import excel
 import get_variant_info as var_info
 from start_process import SortArgs
@@ -98,7 +100,61 @@ class TestWorkbook():
         with pytest.raises(ValueError):
             excel.add_epic_data(self)
 
+    def test_alternative_homozygous_notation_becomes_homozygous(self):
+        '''
+        Test that 'alternative_homozgyous' notation in zygosity is converted to
+        'homozygous' in the workbook
+        '''
+        df = pd.DataFrame([{"Zygosity": "alternate_homozygous"}])
+        print(df)
+        df.loc[df["Zygosity"] == "alternate_homozygous", "Zygosity"] = "homozygous"
+        print("DataFrame after conversion:", df)
 
+        assert "homozygous" in df["Zygosity"].values
+        assert "alternative_homozygous" not in df["Zygosity"].values
+
+    def test_write_snv_report_colouring(self):
+        '''
+        Test that the function to add SNV reporting colouring to the workbook
+        runs without error.
+        '''
+        wb = Workbook()
+        wb.remove(wb.active)
+        writer = excel(None)
+        writer.workbook = wb
+
+        writer.write_snv_reporting_template(1)
+        sheet = wb["snv_interpret_1"]
+
+        # Check G2 and G3 are yellow
+        assert sheet["G2"].fill.start_color.rgb in ("FFFF00", "00FFFF00")
+        assert sheet["G3"].fill.start_color.rgb in ("FFFF00", "00FFFF00")
+
+        # Check all of column M is yellow
+        assert all(
+            sheet[f"M{row}"].fill.start_color.rgb in ("FFFF00", "00FFFF00")
+            for row in range(1, sheet.max_row + 1)
+        )
+
+    def test_cnv_report_colouring(self):
+        '''
+        Test that the function to add CNV reporting colouring to the workbook
+        runs without error.
+        '''
+        wb = Workbook()
+        wb.remove(wb.active)
+        writer = excel(None)
+        writer.workbook = wb
+
+        writer.write_cnv_reporting_template(1)
+        sheet = wb["cnv_interpret_1"]
+
+
+        # Check all of column H is yellow
+        assert all(
+            sheet[f"H{row}"].fill.start_color.rgb in ("FFFF00", "00FFFF00")
+            for row in range(1, sheet.max_row + 1)
+        )
 class TestInterpretationService():
     '''
     Test that the function to find interpretation service works as expected


### PR DESCRIPTION
Changes: 
- Implemented colour labelling to WGS variants interpretation tables
- Now display "alternate_homozygous" variants as "homozygous" in workbook
- Added unit tests for new features

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/31)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CNV and SNV report formatting with yellow highlighting applied to CNV column H, SNV column M and cells G2–G3 for improved visibility

* **Improvements**
  * Normalised zygosity by standardising alternate homozygous notation to homozygous

* **Tests**
  * Added tests verifying zygosity normalisation and the new workbook colouring behaviour

* **Refactor**
  * Safer handling of cell style copies to avoid unintended mutations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->