### PR TITLE
Di 1761 MT filtering logic fixes

### DIFF
--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -375,8 +375,9 @@ def get_top_3_ranked(df):
         variants in the top three ranks
     '''
     # First change "Exomiser Rank #" string to int
+    # extracts the rank from "Exomiser Rank X" and ignores De novo if present
     df['priority_as_int'] = df['Priority'].map(
-        lambda x: int(x.split(' ')[-1])
+        lambda x: int(x.split(';')[0].split(' ')[-1]) if "Exomiser Rank" in x else float('inf')
     )
     # Get unique ranks and sort, selecting the top three ranks
     unique_ranks = df['priority_as_int'].unique()

--- a/resources/home/dnanexus/get_variant_info.py
+++ b/resources/home/dnanexus/get_variant_info.py
@@ -377,8 +377,12 @@ def get_top_3_ranked(df):
     # First change "Exomiser Rank #" string to int
     # extracts the rank from "Exomiser Rank X" and ignores De novo if present
     df['priority_as_int'] = df['Priority'].map(
-        lambda x: int(x.split(';')[0].split(' ')[-1]) if "Exomiser Rank" in x else float('inf')
+        lambda x: int(x.split(';')[0].split(' ')[-1]) if "Exomiser Rank" in x else None
     )
+
+    # Ignore variants without an Exomiser rank
+    df = df[df['priority_as_int'].notna()]
+
     # Get unique ranks and sort, selecting the top three ranks
     unique_ranks = df['priority_as_int'].unique()
     top_3_ranks = sorted(unique_ranks)[:3]

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -920,8 +920,8 @@ class excel():
 
             if not ex_df.empty:
                 # Separate de novo and exomiser variants using case insensitive match
-                denovo_df = ex_df[ex_df['Priority'].str.lower() == 'de novo'].copy()
-                exomiser_df = ex_df[ex_df['Priority'].str.lower() != "de novo"].copy()
+                denovo_df = ex_df[ex_df['Priority'].str.contains("de novo", case=False, na=False)].copy()
+                exomiser_df = ex_df[~ex_df['Priority'].str.contains("de novo", case=False, na=False)].copy()
 
                 if not exomiser_df.empty:
                     exomiser_df = var_info.get_top_3_ranked(exomiser_df)

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -741,21 +741,35 @@ class excel():
             """
             Helper function to look up the highest GEL tier for a mitochondrial variant.
             Returns integer tier or None if no tiered GEL event exists.
+            Inputs:
+                chr_ (str): Chromosome of the variant
+                pos (str): Position of the variant
+                ref (str): Reference allele of the variant
+                alt (str): Alternate allele of the variant
+            Outputs:
+                tier (int or None): Highest clinical GEL tier for the variant, or None if not found
             """
             gel_variants = self.wgs_data[self.genome_format][self.gel_index][self.genome_data_format]["variants"]
 
-            tiers = []
+            tier_nums = []
             for gel_snv in gel_variants:
-                if (str(gel_snv.get("chromosome")) == str(chr_) and
-                    str(gel_snv.get("position")) == str(pos) and
-                    str(gel_snv.get("reference")) == str(ref) and
-                    str(gel_snv.get("alternate")) == str(alt)):
+                coords = gel_snv.get("variantCoordinates", {})
+                if (
+                    str(coords.get("chromosome")) == str(chr_) and
+                    str(coords.get("position")) == str(pos) and
+                    str(coords.get("reference")) == str(ref) and
+                    str(coords.get("alternate")) == str(alt)
+                ):
+                    for event in gel_snv["reportEvents"]:
+                        tier_str = event.get("tier")
+                        if tier_str is not None:
+                            # Extract numeric tier (e.g. "TIER3" -> 3)
+                            match = re.search(r'\d+', tier_str)
+                            if match:
+                                tier_nums.append(int(match.group()))
 
-                    for ge in gel_snv["reportEvents"]:
-                        if ge.get("tier") is not None:
-                            tiers.append(ge["tier"])
-
-            return min(tiers) if tiers else None
+                    return min(tier_nums) if tier_nums else None
+            return None
 
         variant_list = []
         ranked = []
@@ -772,6 +786,10 @@ class excel():
             ref = snv.get("reference") or snv.get("Ref")
             alt = snv.get("alternate") or snv.get("Alt")
 
+            # If MT GEL variant not found, skip to next variant
+            if None in [chr_, pos, ref, alt]:
+                continue
+
             is_mt = str(chr_) == "MT"
 
             for event in snv["reportEvents"]:
@@ -780,12 +798,12 @@ class excel():
                     gel_tier = get_mt_gel_tier(chr_, pos, ref, alt)
 
                     # Keep only MT variants with GEL tier = 3
-                    if gel_tier is not None and gel_tier >= 3:
+                    if gel_tier is not None:
                         ev_to_look_at.append(event)
 
-                    continue
                 # Keep all autosomal events
-                ev_to_look_at.append(event)
+                else:
+                    ev_to_look_at.append(event)
 
             # if we have a list of non MT/untiered events, get highest
             # ranked event from this list + set it as the only report event
@@ -797,15 +815,11 @@ class excel():
                 snv['reportEvents'] = top_event
                 ranked.append(snv)
 
-        print("Ranked variants:", len(ranked))
-
         # We only want Exomiser variants with a score >= 0.75, so we need to
         # filter the list to keep only these
         ranked_and_above_threshold = [
             x for x in ranked if x['reportEvents']['score'] >= 0.75
         ]
-
-        print("Above threshold:", len(ranked_and_above_threshold))
 
         for snv in ranked_and_above_threshold:
             # put reportevents dict within a list to allow it to have an index
@@ -850,7 +864,7 @@ class excel():
                         self.father,
                         self.proband_sex
                     )
-                    if "Priority" in var_dict:
+                    if var_dict.get("Priority"):
                         var_dict["Priority"] += "; De novo"
                     else:
                         var_dict["Priority"] = "De novo"
@@ -865,8 +879,6 @@ class excel():
 
         ex_df = pd.DataFrame(variant_list)
         ex_df = ex_df.drop_duplicates()
-
-        print("ex_df before merge:", len(ex_df))
 
         if not ex_df.empty and not self.var_df.empty:
             # Convert all df columns to object type to allow merging without
@@ -916,7 +928,6 @@ class excel():
             # Clean up df by dropping merge column and columns ending _y
             cols_to_drop = [c for c in merge_df.columns if c.endswith("_y")]
             ex_df = merge_df.drop(columns=cols_to_drop)
-            print("ex_df after merge:", len(ex_df))
 
             if not ex_df.empty:
                 # Separate de novo and exomiser variants using case insensitive match

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -737,6 +737,26 @@ class excel():
         Outputs:
             None, adds content to openpxyl workbook
         '''
+        def get_mt_gel_tier(chr_, pos, ref, alt):
+            """
+            Helper function to look up the highest GEL tier for a mitochondrial variant.
+            Returns integer tier or None if no tiered GEL event exists.
+            """
+            gel_variants = self.wgs_data[self.genome_format][self.gel_index][self.genome_data_format]["variants"]
+
+            tiers = []
+            for gel_snv in gel_variants:
+                if (str(gel_snv.get("chromosome")) == str(chr_) and
+                    str(gel_snv.get("position")) == str(pos) and
+                    str(gel_snv.get("reference")) == str(ref) and
+                    str(gel_snv.get("alternate")) == str(alt)):
+
+                    for ge in gel_snv["reportEvents"]:
+                        if ge.get("tier") is not None:
+                            tiers.append(ge["tier"])
+
+            return min(tiers) if tiers else None
+
         variant_list = []
         ranked = []
         # Look through Exomiser SNVs and return those that are ranked

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -790,7 +790,7 @@ class excel():
 
             # If MT GEL variant not found, skip to next variant
             if None in [chr_, pos, ref, alt]:
-                raise ValueError(f"Exomiser SNV missing required coordinates: (chromosome/position/ref/alt)")
+                raise ValueError("Exomiser SNV missing required coordinates: (chromosome/position/ref/alt)")
 
             is_mt = str(chr_) == "MT"
 
@@ -970,8 +970,8 @@ class excel():
         # Add exomiser/de novo variant counts to summary sheet
         summary_sheet = self.workbook["Summary"]
         if 'Priority' in ex_df.columns:
-            summary_sheet['B31'] = ex_df['Priority'].str.startswith(
-                "De novo"
+            summary_sheet['B31'] = ex_df['Priority'].str.contains(
+                r'\bde novo\b', case=False, na=False
             ).sum()
             summary_sheet['B30'] = ex_df['Priority'].str.startswith(
                 'Exomiser'

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -781,14 +781,16 @@ class excel():
             ev_to_look_at = []
 
             # Get chr, pos, ref, alt for use in MT GEL tier lookup
-            chr_ = snv.get("chromosome") or snv.get("Chr")
-            pos = snv.get("position") or snv.get("Pos")
-            ref = snv.get("reference") or snv.get("Ref")
-            alt = snv.get("alternate") or snv.get("Alt")
+            coords = snv.get("variantCoordinates", {})
+            chr_ = coords.get("chromosome")
+            pos = coords.get("position")
+            ref = coords.get("reference")
+            alt = coords.get("alternate")
+
 
             # If MT GEL variant not found, skip to next variant
             if None in [chr_, pos, ref, alt]:
-                continue
+                raise ValueError(f"Exomiser SNV missing required coordinates: {snv}")
 
             is_mt = str(chr_) == "MT"
 
@@ -797,7 +799,7 @@ class excel():
                 if is_mt:
                     gel_tier = get_mt_gel_tier(chr_, pos, ref, alt)
 
-                    # Keep only MT variants with GEL tier = 3
+                    # Keep only MT variants with a GEL tier
                     if gel_tier is not None:
                         ev_to_look_at.append(event)
 

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -775,7 +775,7 @@ class excel():
             is_mt = str(chr_) == "MT"
 
             for event in snv["reportEvents"]:
-                # NEW: MT variants must use GEL tier, not Exomiser tier
+                #  MT variants must use GEL tier, not Exomiser tier
                 if is_mt:
                     gel_tier = get_mt_gel_tier(chr_, pos, ref, alt)
 
@@ -784,12 +784,8 @@ class excel():
                         ev_to_look_at.append(event)
 
                     continue
-                # Filter out mitochondrial + untiered as these are likely
-                # artifacts
-                if event['tier'] is None:
-                    continue
-                else:
-                    ev_to_look_at.append(event)
+                # Keep all autosomal events
+                ev_to_look_at.append(event)
 
             # if we have a list of non MT/untiered events, get highest
             # ranked event from this list + set it as the only report event
@@ -801,11 +797,15 @@ class excel():
                 snv['reportEvents'] = top_event
                 ranked.append(snv)
 
+        print("Ranked variants:", len(ranked))
+
         # We only want Exomiser variants with a score >= 0.75, so we need to
         # filter the list to keep only these
         ranked_and_above_threshold = [
             x for x in ranked if x['reportEvents']['score'] >= 0.75
         ]
+
+        print("Above threshold:", len(ranked_and_above_threshold))
 
         for snv in ranked_and_above_threshold:
             # put reportevents dict within a list to allow it to have an index
@@ -865,6 +865,9 @@ class excel():
 
         ex_df = pd.DataFrame(variant_list)
         ex_df = ex_df.drop_duplicates()
+
+        print("ex_df before merge:", len(ex_df))
+
         if not ex_df.empty and not self.var_df.empty:
             # Convert all df columns to object type to allow merging without
             # conflicts
@@ -913,6 +916,7 @@ class excel():
             # Clean up df by dropping merge column and columns ending _y
             cols_to_drop = [c for c in merge_df.columns if c.endswith("_y")]
             ex_df = merge_df.drop(columns=cols_to_drop)
+            print("ex_df after merge:", len(ex_df))
 
             if not ex_df.empty:
                 # Separate de novo and exomiser variants using case insensitive match

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -765,7 +765,25 @@ class excel():
                 self.ex_index
             ][self.genome_data_format]["variants"]:
             ev_to_look_at = []
+
+            # Get chr, pos, ref, alt for use in MT GEL tier lookup
+            chr_ = snv.get("chromosome") or snv.get("Chr")
+            pos = snv.get("position") or snv.get("Pos")
+            ref = snv.get("reference") or snv.get("Ref")
+            alt = snv.get("alternate") or snv.get("Alt")
+
+            is_mt = str(chr_) == "MT"
+
             for event in snv["reportEvents"]:
+                # NEW: MT variants must use GEL tier, not Exomiser tier
+                if is_mt:
+                    gel_tier = get_mt_gel_tier(chr_, pos, ref, alt)
+
+                    # Keep only MT variants with GEL tier = 3
+                    if gel_tier is not None and gel_tier >= 3:
+                        ev_to_look_at.append(event)
+
+                    continue
                 # Filter out mitochondrial + untiered as these are likely
                 # artifacts
                 if event['tier'] is None:
@@ -832,7 +850,10 @@ class excel():
                         self.father,
                         self.proband_sex
                     )
-                    var_dict["Priority"] = "De novo"
+                    if "Priority" in var_dict:
+                        var_dict["Priority"] += "; De novo"
+                    else:
+                        var_dict["Priority"] = "De novo"
                     var_dict["Inheritance"] = "De novo"
                     var_dict["HGVSc"], var_dict["HGVSp"] = (
                         var_info.get_hgvs_gel(

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -790,7 +790,7 @@ class excel():
 
             # If MT GEL variant not found, skip to next variant
             if None in [chr_, pos, ref, alt]:
-                raise ValueError(f"Exomiser SNV missing required coordinates: {snv}")
+                raise ValueError(f"Exomiser SNV missing required coordinates: (chromosome/position/ref/alt)")
 
             is_mt = str(chr_) == "MT"
 

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -449,11 +449,19 @@ class TestWorkbook():
         mt_positions = {int(pos) for chr_, pos in zip(df["Chr"], df["Pos"]) if chr_ == "MT"}
 
         # Check only expected MT positions are present in df
-        # Has no GEL or exomiser tiering
+        # 12345 will be excluded.
+        # Has exomiser dataset but no GEL and exomiser tiering
+        # Tier and Tier_y are both null
         assert 12345 not in mt_positions
-        # Has no Exomiser tiering
+
+        # 67890 will be excluded.
+        # Has GEL tiering but no matching Exomiser tiering dataset
+        # GEL only variants are don't go through exomiser pipeline
         assert 67890 not in mt_positions
-        # Has Exomiser and GEL tiering
+
+        # 11121 will be included
+        # Has Exomiser and matching GEL tiering dataset
+        # Passes MT filtering with at least one tier present are kept
         assert 11121 in mt_positions
 
 class TestInterpretationService():

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -313,6 +313,9 @@ class TestWorkbook():
                 "Priority": "Exomiser Rank 1",
                 "HGVSc": "c.123A>G",
                 "HGVSp": "p.Arg123Gly",
+                "Consequence": "missense_variant",
+                "Zygosity": "het",
+                "Sample": "TESTSAMPLE",
             }
 
         # Create mock excel instance
@@ -337,7 +340,7 @@ class TestWorkbook():
 
         # Added test var_df to check MT variant filtering
         excel_instance.var_df = pd.DataFrame([
-            {"Chr": "1", "Pos": 99999, "Ref": "A", "Alt": "G"},
+            {"Chr": "MT", "Pos": 12345, "Ref": "A", "Alt": "G"}
         ])
 
         # Create valid Exomiser event as helper function
@@ -355,22 +358,9 @@ class TestWorkbook():
         # Create wgs_data with MT variants for testing
         excel_instance.wgs_data = {
             "interpretedGenomes": {
-                1: {
+                0: {    # Create GEL variants
                     "interpretedGenomeData": {
                         "variants": [
-                            # Should be excluded (both tiers null)
-                            {
-                                "variantCoordinates": {
-                                    "chromosome": "MT",
-                                    "position": 12345,
-                                    "reference": "A",
-                                    "alternate": "G",
-                                },
-                                "gel_tiering": None,
-                                "exomiser": None,
-                                "reportEvents": [make_event(None)],
-                            },
-                            # Should be included (TIER3 in gel_tiering)
                             {
                                 "variantCoordinates": {
                                     "chromosome": "MT",
@@ -382,8 +372,43 @@ class TestWorkbook():
                                 "exomiser": None,
                                 "reportEvents": [make_event("TIER3")],
                             },
-                            # Should be included (TIER3 in exomiser)
                             {
+                                "variantCoordinates": {
+                                    "chromosome": "MT",
+                                    "position": 11121,
+                                    "reference": "G",
+                                    "alternate": "A",
+                                },
+                                "gel_tiering": "TIER3",
+                                "exomiser": None,
+                                "reportEvents": [make_event("TIER3")],
+                            }
+                        ]
+                    }
+                },
+                1: {
+                    "interpretedGenomeData": {
+                        "variants": [
+                            {
+                                "chromosome": "MT",
+                                "position": 12345,
+                                "reference": "A",
+                                "alternate": "G",
+                                "variantCoordinates": {
+                                    "chromosome": "MT",
+                                    "position": 12345,
+                                    "reference": "A",
+                                    "alternate": "G",
+                                },
+                                "gel_tiering": None,
+                                "exomiser": None,
+                                "reportEvents": [make_event(None)],
+                            },
+                            {
+                                "chromosome": "MT",
+                                "position": 11121,
+                                "reference": "G",
+                                "alternate": "A",
                                 "variantCoordinates": {
                                     "chromosome": "MT",
                                     "position": 11121,
@@ -393,11 +418,10 @@ class TestWorkbook():
                                 "gel_tiering": None,
                                 "exomiser": "TIER3",
                                 "reportEvents": [make_event("TIER3")],
-                            },
+                            }
                         ]
                     }
-                },
-                0: {"interpretedGenomeData": {"variants": []}},
+                }
             }
         }
 
@@ -425,8 +449,11 @@ class TestWorkbook():
         mt_positions = {int(pos) for chr_, pos in zip(df["Chr"], df["Pos"]) if chr_ == "MT"}
 
         # Check only expected MT positions are present in df
+        # Has no GEL or exomiser tiering
         assert 12345 not in mt_positions
-        assert 67890 in mt_positions
+        # Has no Exomiser tiering
+        assert 67890 not in mt_positions
+        # Has Exomiser and GEL tiering
         assert 11121 in mt_positions
 
 class TestInterpretationService():


### PR DESCRIPTION
Changes :
- Added helper function to filter highest GEL tier MT variants
- Show exomiser and de novo priority ranks
- fixed logic to keep untiered autosomal variants
- fixed crash in get_top_3_ ranked function where de novo is also a priority
- updated logic after crash fix so variants with exomiser and denovo priority are not duplicated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/36)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced GEL tiering for mitochondrial variants; MT events retained only if a GEL or Exomiser tier exists.
  * De novo status preserved and annotated in Priority and Inheritance fields.

* **Bug Fixes**
  * Robust Exomiser rank parsing; non‑matching ranks are ignored before ranking.
  * Improved merging/deduplication of variant records and case‑insensitive de novo detection.

* **Tests**
  * Updated unit tests and mock data to reflect MT filtering and ranking logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->