### PR TITLE
Di 1761 MT zygosity fix

### DIFF
--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -639,8 +639,7 @@ class excel():
                         self.father,
                         self.proband_sex
                         )
-                    if var_dict.get("Zygosity") == "alternate_homozygous":
-                        var_dict["Zygosity"] = "homozygous"
+                    var_dict = self._normalise_zygosity(var_dict)
                     c_dot, p_dot = var_info.get_hgvs_gel(
                         snv,
                         self.mane,
@@ -728,6 +727,11 @@ class excel():
 
         # Set column widths
         ExcelStyles.resize_variant_columns(self, self.workbook["Variants"])
+
+    def _normalise_zygosity(self, var_dict):
+        if var_dict.get("Zygosity") == "alternate_homozygous":
+            var_dict["Zygosity"] = "homozygous"
+        return var_dict
 
     def create_additional_analysis_page(self):
         '''
@@ -847,8 +851,7 @@ class excel():
                     self.refseq_tsv)
                 )
             # Normalise Exomiser/MT zygosity
-            if var_dict.get("Zygosity") == "alternate_homozygous":
-                var_dict["Zygosity"] = "homozygous"
+            var_dict = self._normalise_zygosity(var_dict)
 
             variant_list.append(var_dict)
 
@@ -882,8 +885,7 @@ class excel():
                             self.refseq_tsv)
                     )
                     # Normalise Exomiser/MT zygosity
-                    if var_dict.get("Zygosity") == "alternate_homozygous":
-                        var_dict["Zygosity"] = "homozygous"
+                    var_dict = self._normalise_zygosity(var_dict)
 
                     variant_list.append(var_dict)
 

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -846,6 +846,10 @@ class excel():
                     self.mane,
                     self.refseq_tsv)
                 )
+            # Normalise Exomiser/MT zygosity
+            if var_dict.get("Zygosity") == "alternate_homozygous":
+                var_dict["Zygosity"] = "homozygous"
+
             variant_list.append(var_dict)
 
         # Get variants with high de novo quality score (these are either SNVs
@@ -877,6 +881,10 @@ class excel():
                             self.mane,
                             self.refseq_tsv)
                     )
+                    # Normalise Exomiser/MT zygosity
+                    if var_dict.get("Zygosity") == "alternate_homozygous":
+                        var_dict["Zygosity"] = "homozygous"
+
                     variant_list.append(var_dict)
 
         ex_df = pd.DataFrame(variant_list)

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -884,7 +884,7 @@ class excel():
                             self.mane,
                             self.refseq_tsv)
                     )
-                    # Normalise Exomiser/MT zygosity
+                    # Normalise zygosity (e.g. alternate_homozygous to homozygous)
                     var_dict = self._normalise_zygosity(var_dict)
 
                     variant_list.append(var_dict)


### PR DESCRIPTION
Handled zygosity for MT SNVs to change label from alternate_homozygous to homozygous in workbook

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/37)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardised zygosity terminology across tiering, MT, Exomiser and additional analysis pages—variants previously labelled as "alternate_homozygous" are now shown consistently as "homozygous".
  * Ensures consistent zygosity display for De Novo, MT and Exomiser-derived variants across the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->