### PR TITLE
Di 1761 interpretation flag formatting in workbook

### DIFF
--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -243,7 +243,7 @@ class excel():
 
         flags = req.get(key)
         return {
-            (1, 9): str(flags) if flags else None,
+            (1, 9): flags[0].get("interpretationFlag") if isinstance(flags, list) and flags else None,
             (1, 2): data["family_id"]
         }
 

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -242,9 +242,12 @@ class excel():
         )
 
         flags = req.get(key)
+        if isinstance(flags, list) and flags and isinstance(flags[0], dict):
+            flag_value = flags[0].get("interpretationFlag") or flags[0].get("flag")
+        else:
+            flag_value = None
         return {
-            (1, 9): (flags[0].get("interpretationFlag") or flags[0].get("flag"))
-                if isinstance(flags, list) and flags else None,
+            (1, 9): flag_value,
             (1, 2): data["family_id"]
         }
 

--- a/resources/home/dnanexus/make_workbook.py
+++ b/resources/home/dnanexus/make_workbook.py
@@ -243,7 +243,8 @@ class excel():
 
         flags = req.get(key)
         return {
-            (1, 9): flags[0].get("interpretationFlag") if isinstance(flags, list) and flags else None,
+            (1, 9): (flags[0].get("interpretationFlag") or flags[0].get("flag"))
+                if isinstance(flags, list) and flags else None,
             (1, 2): data["family_id"]
         }
 

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -1016,6 +1016,13 @@ class TestInterpretationFlags():
         result = excel_instance.get_summary_content(data)
         assert result[(1, 2)] == "FAM12345"
 
+    # Snake_case keys are accepted as well as camelCase
+    def test_snake_case_interpretation_flags_key(self):
+        data = self._make_wgs_data(
+            {"interpretation_flags": [{"interpretationFlag": "snake_flag"}]}
+        )
+        assert self._get_flags_cell(data) == "snake_flag"
+
 
 class TestWorkbookName:
     def test_workbook_name_generation(self):

--- a/resources/home/dnanexus/tests/test_make_workbook.py
+++ b/resources/home/dnanexus/tests/test_make_workbook.py
@@ -952,29 +952,68 @@ class TestHpoTerms():
 
 class TestInterpretationFlags():
     '''
-    Tests for interpretation flags extraction from JSON request
+    Tests for interpretation flags extraction in get_summary_content,
+    matching the behaviour of the current implementation.
     '''
-    wgs_data = {
-        "family_id": "FAM12345",
-        "interpretation_request_data": {
-            "json_request": {
-                "interpretation_flags": "Flag1, Flag2, Flag3"
+    @staticmethod
+    def _make_wgs_data(json_request_extra: dict) -> dict:
+        return {
+            "family_id": "FAM12345",
+            "interpretation_request_data": {
+                "json_request": json_request_extra
             }
-        },
-    }
-    summary_content = {}
+        }
 
-    def test_interpretation_flags_extraction(self,wgs_data=wgs_data):
-        '''
-        Test that interpretation flags are correctly extracted from JSON request
-        and added to summary_content dictionary.
-        '''
-        mock_args = MagicMock()
-        excel_instance = excel(mock_args)
-        result = excel_instance.get_summary_content(wgs_data)
-        summary_content = result.get((1, 9))
-        expected_flags = "Flag1, Flag2, Flag3"
-        assert summary_content == expected_flags
+    @staticmethod
+    def _get_flags_cell(wgs_data: dict):
+        excel_instance = excel(MagicMock())
+        return excel_instance.get_summary_content(wgs_data).get((1, 9))
+
+
+    # List of dicts — value under 'interpretationFlag'
+
+    def test_list_of_dicts_interpretation_flag_key(self):
+        data = self._make_wgs_data(
+            {"interpretationFlags": [{"interpretationFlag": "interesting_flag"}]}
+        )
+        assert self._get_flags_cell(data) == "interesting_flag"
+
+    # List of dicts — value under 'flag'
+    def test_list_of_dicts_flag_key_fallback(self):
+        data = self._make_wgs_data(
+            {"interpretationFlags": [{"flag": "fallback_flag"}]}
+        )
+        assert self._get_flags_cell(data) == "fallback_flag"
+
+    # interpretationFlag empty → fallback to flag
+    def test_list_of_dicts_empty_interpretation_flag_falls_back_to_flag(self):
+        data = self._make_wgs_data(
+            {"interpretationFlags": [{"interpretationFlag": "", "flag": "backup_flag"}]}
+        )
+        assert self._get_flags_cell(data) == "backup_flag"
+
+    # Missing key → None
+    def test_missing_flags_key_returns_none(self):
+        data = self._make_wgs_data({})
+        assert self._get_flags_cell(data) is None
+
+    # Empty list → None
+    def test_empty_list_returns_none(self):
+        data = self._make_wgs_data({"interpretationFlags": []})
+        assert self._get_flags_cell(data) is None
+
+    # List whose first element is not a dict → None
+    def test_list_of_non_dicts_returns_none(self):
+        data = self._make_wgs_data(
+            {"interpretationFlags": ["plain_string_entry"]}
+        )
+        assert self._get_flags_cell(data) is None
+
+    # family_id always returned
+    def test_family_id_always_returned(self):
+        data = self._make_wgs_data({})
+        excel_instance = excel(MagicMock())
+        result = excel_instance.get_summary_content(data)
         assert result[(1, 2)] == "FAM12345"
 
 


### PR DESCRIPTION
Changes:
- Changed flag formatting to not include json metadata
- Added handling of flags for both 'interpretationFlag' or 'flag' before formatting

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_rd_wgs_workbook/40)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise flag handling in Summary sheets: extracts a single meaningful flag value (preferring a specific attribute with sensible fallbacks) and avoids writing raw object strings, improving clarity in generated workbooks.

* **Tests**
  * Expanded test coverage for the new flag extraction behaviour across multiple input shapes, including camelCase and snake_case variants, and retained checks for consistent family ID output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->